### PR TITLE
Integration tests for ixdiagnose

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,0 +1,22 @@
+name: ixdiagnose_test
+
+on:
+  push:
+    branches:
+      - '*'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/truenas/ixdiagnose:master
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Deps
+      run: |
+        pip install -r requirements.txt
+        pip install -U .
+    - name: Running test
+      run: pytest -v ixdiagnose/test/pytest/integration/

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,9 +1,10 @@
-name: ixdiagnose_test
+name: integration_tests
 
 on:
-  push:
-    branches:
-      - '*'
+  pull_request:
+    types:
+      - 'synchronize'
+      - 'opened'
 
 jobs:
   build:

--- a/ixdiagnose/plugins/active_directory.py
+++ b/ixdiagnose/plugins/active_directory.py
@@ -23,8 +23,8 @@ class ActiveDirectory(Plugin):
                 Command(['wbinfo', '--all-domains'], 'Active directory of all domains.', serializable=False),
                 Command(['wbinfo', '--own-domain'], 'Active directory own domains', serializable=False),
                 Command(['wbinfo', '--online-status'], 'Active directory online status.', serializable=False),
-                Command(['wbinfo -u'], 'Active directory Users', serializable=False, max_lines=50),
-                Command(['wbinfo -g'], 'Active directory Groups.', serializable=False, max_lines=50),
+                Command(['wbinfo', '-u'], 'Active directory Users', serializable=False, max_lines=50),
+                Command(['wbinfo', '-g'], 'Active directory Groups.', serializable=False, max_lines=50),
                 Command(
                     'wbinfo --domain-info="$(wbinfo --own-domain)"', 'Active directory domain information.',
                     serializable=False,
@@ -41,7 +41,7 @@ class ActiveDirectory(Plugin):
         CommandMetric(
             'ad_join_status', [
                 Command(
-                    ['net', '-d', 5, '-k', 'ads', 'testjoin'], 'Active Directory Join Status.', serializable=False
+                    ['net', '-d', '5', '-k', 'ads', 'testjoin'], 'Active Directory Join Status.', serializable=False
                 ),
             ], prerequisites=[ActiveDirectoryStatePrerequisite()],
         ),

--- a/ixdiagnose/plugins/base.py
+++ b/ixdiagnose/plugins/base.py
@@ -44,7 +44,8 @@ class Plugin:
             with get_middleware_client() as client:
                 context['middleware_client'] = client
                 return self.execute_impl(context)
-        except ConnectionError:
+        except (ConnectionError, FileNotFoundError):
+            # ConnectionError/FileNotFoundError is raised when middleware is not running
             return self.execute_impl(context)
 
     def execute_impl(self, context: dict) -> None:

--- a/ixdiagnose/test/pytest/integration/test_artifacts.py
+++ b/ixdiagnose/test/pytest/integration/test_artifacts.py
@@ -59,8 +59,7 @@ def gather_artifacts():
 
 def get_artifacts_dirs(base_artifact_dir) -> list:
     return [
-        os.path.join(base_artifact_dir, i) for i in os.listdir(base_artifact_dir)
-        if os.path.isdir(os.path.join(base_artifact_dir, i))
+        i.path for i in os.scandir(base_artifact_dir) if i.is_dir()
     ]
 
 

--- a/ixdiagnose/test/pytest/integration/test_artifacts.py
+++ b/ixdiagnose/test/pytest/integration/test_artifacts.py
@@ -1,9 +1,36 @@
 import contextlib
+import json
 import os
 import shutil
 
 from ixdiagnose.artifact import artifact_factory, gather_artifacts as gather_artifacts_impl
 from ixdiagnose.config import conf
+from jsonschema import validate
+
+from .utils import BASE_REPORT_SCHEMA
+
+
+ARTIFACT_REPORT_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'execution_time': {'type': 'number'},
+        'item_report': {
+            'anyOf': [
+                {
+                    'type': 'object',
+                    'properties': {
+                        'error': {'type': ['string', 'null', 'object']},
+                        'traceback': {'type': ['string', 'null']},
+                        'copied_items': {'type': 'array'},
+                    },
+                },
+                {'type': 'null'}
+            ]
+        },
+        'item_execution_error': {'type': ['string', 'null']},
+        'item_execution_traceback': {'type': ['string', 'null']},
+    },
+}
 
 
 @contextlib.contextmanager
@@ -42,3 +69,25 @@ def test_artifacts_count():
     with gather_artifacts() as artifacts_dir:
         artifacts_dirs = get_artifacts_dirs(artifacts_dir)
         assert len(artifacts_dirs) == len(artifact_factory.get_items())
+
+
+def test_report_schema():
+    artifacts = artifact_factory.get_items()
+    with gather_artifacts() as artifacts_dir:
+        with open(os.path.join(artifacts_dir, 'report.json')) as f:
+            base_report = json.loads(f.read())
+
+        assert set(artifacts) == set(base_report)
+
+        for artifact_name, artifact_report in base_report.items():
+            validate(base_report[artifact_name], BASE_REPORT_SCHEMA)
+
+        for artifact_dir in get_artifacts_dirs(artifacts_dir):
+            with open(os.path.join(artifact_dir, 'report.json')) as f:
+                artifact_report = json.loads(f.read())
+
+            artifact = artifacts[os.path.basename(artifact_dir)]
+            assert {item.name for item in artifact.items} == set(artifact_report)
+
+            for item_report in artifact_report.values():
+                validate(item_report, ARTIFACT_REPORT_SCHEMA)

--- a/ixdiagnose/test/pytest/integration/test_artifacts.py
+++ b/ixdiagnose/test/pytest/integration/test_artifacts.py
@@ -1,0 +1,44 @@
+import contextlib
+import os
+import shutil
+
+from ixdiagnose.artifact import artifact_factory, gather_artifacts as gather_artifacts_impl
+from ixdiagnose.config import conf
+
+
+@contextlib.contextmanager
+def gather_artifacts():
+    conf.debug_path = '/tmp/ixdiagnose'
+    os.makedirs(conf.debug_path, exist_ok=True)
+
+    try:
+        gather_artifacts_impl()
+        yield os.path.join(conf.debug_path, 'debug/artifacts')
+    finally:
+        shutil.rmtree(conf.debug_path, ignore_errors=True)
+
+
+def get_artifacts_dirs(base_artifact_dir) -> list:
+    return [
+        os.path.join(base_artifact_dir, i) for i in os.listdir(base_artifact_dir)
+        if os.path.isdir(os.path.join(base_artifact_dir, i))
+    ]
+
+
+def test_base_report_generation():
+    with gather_artifacts() as artifacts_dir:
+        assert os.path.exists(os.path.join(artifacts_dir, 'report.json')) is True
+
+
+def test_artifacts_directories_report_generation():
+    with gather_artifacts() as artifacts_dir:
+        artifacts_dirs = get_artifacts_dirs(artifacts_dir)
+        assert len(artifacts_dirs) > 0
+        for artifact_dir in artifacts_dirs:
+            assert os.path.exists(os.path.join(artifact_dir, 'report.json')) is True
+
+
+def test_artifacts_count():
+    with gather_artifacts() as artifacts_dir:
+        artifacts_dirs = get_artifacts_dirs(artifacts_dir)
+        assert len(artifacts_dirs) == len(artifact_factory.get_items())

--- a/ixdiagnose/test/pytest/integration/test_plugins.py
+++ b/ixdiagnose/test/pytest/integration/test_plugins.py
@@ -59,8 +59,7 @@ def generate_plugins():
 
 def get_plugins_dirs(base_plugins_dir) -> list:
     return [
-        os.path.join(base_plugins_dir, i) for i in os.listdir(base_plugins_dir)
-        if os.path.isdir(os.path.join(base_plugins_dir, i))
+        i.path for i in os.scandir(base_plugins_dir) if i.is_dir()
     ]
 
 

--- a/ixdiagnose/test/pytest/integration/test_plugins.py
+++ b/ixdiagnose/test/pytest/integration/test_plugins.py
@@ -1,9 +1,48 @@
 import contextlib
+import json
 import os
 import shutil
 
 from ixdiagnose.config import conf
 from ixdiagnose.plugin import generate_plugins_debug, plugin_factory
+from jsonschema import validate
+
+from .utils import BASE_REPORT_SCHEMA
+
+
+PLUGINS_REPORT_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'execution_time': {'type': 'number'},
+        'metric_report': {
+            'anyOf': [
+                {
+                    'type': 'array',
+                    'items': {
+                        'type': 'object',
+                        'properties': {
+                            'error': {'type': ['string', 'null', 'object']},
+                            'command': {'type': ['string', 'array']},
+                            'execution_time': {'type': 'number'},
+                            'description': {'type': ['string', 'null']},
+                            'returncode': {'type': 'integer'},
+                            'endpoint': {'type': 'string'},
+                        },
+                    }
+                },
+                {
+                    'type': 'object',
+                    'properties': {
+                        'error': {'type': ['string', 'null']}
+                    }
+                },
+            ],
+
+        },
+        'metric_execution_error': {'type': ['string', 'null']},
+        'metric_execution_traceback': {'type': ['string', 'null']},
+    },
+}
 
 
 @contextlib.contextmanager
@@ -42,3 +81,24 @@ def test_plugins_count():
     with generate_plugins() as plugins_dir:
         plugins_dirs = get_plugins_dirs(plugins_dir)
         assert len(plugins_dirs) == len(plugin_factory.get_items())
+
+
+def test_report_schema():
+    with generate_plugins() as plugins_dir:
+        with open(os.path.join(plugins_dir, 'report.json')) as f:
+            base_report = json.loads(f.read())
+
+        assert set(plugin_factory.get_items()) == set(base_report)
+
+        for plugin_name, plugin_report in base_report.items():
+            validate(base_report[plugin_name], BASE_REPORT_SCHEMA)
+
+        for plugin_dir in get_plugins_dirs(plugins_dir):
+            with open(os.path.join(plugin_dir, 'report.json')) as f:
+                plugin_report = json.loads(f.read())
+
+            plugin = plugin_factory.get_items()[os.path.basename(plugin_dir)]
+            assert {metric.name for metric in plugin.metrics_to_execute()} == set(plugin_report)
+
+            for metric_report in plugin_report.values():
+                validate(metric_report, PLUGINS_REPORT_SCHEMA)

--- a/ixdiagnose/test/pytest/integration/test_plugins.py
+++ b/ixdiagnose/test/pytest/integration/test_plugins.py
@@ -1,0 +1,44 @@
+import contextlib
+import os
+import shutil
+
+from ixdiagnose.config import conf
+from ixdiagnose.plugin import generate_plugins_debug, plugin_factory
+
+
+@contextlib.contextmanager
+def generate_plugins():
+    conf.debug_path = '/tmp/ixdiagnose'
+    os.makedirs(conf.debug_path, exist_ok=True)
+
+    try:
+        generate_plugins_debug()
+        yield os.path.join(conf.debug_path, 'debug/plugins')
+    finally:
+        shutil.rmtree(conf.debug_path, ignore_errors=True)
+
+
+def get_plugins_dirs(base_plugins_dir) -> list:
+    return [
+        os.path.join(base_plugins_dir, i) for i in os.listdir(base_plugins_dir)
+        if os.path.isdir(os.path.join(base_plugins_dir, i))
+    ]
+
+
+def test_base_report_generation():
+    with generate_plugins() as plugins_dir:
+        assert os.path.exists(os.path.join(plugins_dir, 'report.json')) is True
+
+
+def test_plugins_directories_report_generation():
+    with generate_plugins() as plugins_dir:
+        plugins_dirs = get_plugins_dirs(plugins_dir)
+        assert len(plugins_dirs) > 0
+        for plugin_dir in plugins_dirs:
+            assert os.path.exists(os.path.join(plugin_dir, 'report.json')) is True
+
+
+def test_plugins_count():
+    with generate_plugins() as plugins_dir:
+        plugins_dirs = get_plugins_dirs(plugins_dir)
+        assert len(plugins_dirs) == len(plugin_factory.get_items())

--- a/ixdiagnose/test/pytest/integration/utils.py
+++ b/ixdiagnose/test/pytest/integration/utils.py
@@ -1,0 +1,8 @@
+BASE_REPORT_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'execution_time': {'type': 'number'},
+        'execution_error': {'type': ['string', 'null']},
+        'execution_traceback': {'type': ['string', 'null']},
+    }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+jsonschema
 pytest
 pytest-mock


### PR DESCRIPTION
## Context

Integration tests have been added to validate 2 parts of ixdiagnose:

1. plugins
2. artifacts

(1) will validate that all plugins are executed and their report is appropriately generated whilst also making sure that all metrics in a plugin are executed with their report generated.

(2) will validate that all artifacts are gathered and their report is appropriately generated whilst also making sure that all items in an artifact are gathered with their report generated.