### PR TITLE
Extend the configuration model to be able to change behaviour of debug generation

### DIFF
--- a/ixdiagnose/config.py
+++ b/ixdiagnose/config.py
@@ -11,6 +11,7 @@ class Configuration:
             'compressed_path': {'type': ['string', 'null']},
             'clean_debug_path': {'type': 'boolean'},
             'debug_path': {'type': ['string', 'null']},
+            'structured_data': {'type': 'boolean'},
             'timeout': {'type': 'integer'},
         },
     }
@@ -20,6 +21,7 @@ class Configuration:
         self.compressed_path: Optional[str] = None
         self.clean_debug_path: bool = False
         self.debug_path: Optional[str] = None
+        self.structured_data: bool = False
         self.timeout: int = 20
 
     def apply(self, new_config: dict) -> None:

--- a/ixdiagnose/config.py
+++ b/ixdiagnose/config.py
@@ -1,13 +1,30 @@
+from jsonschema import validate
 from typing import Optional
 
 
 class Configuration:
+
+    SCHEMA = {
+        'type': 'object',
+        'properties': {
+            'compress': {'type': 'boolean'},
+            'compressed_path': {'type': ['string', 'null']},
+            'clean_debug_path': {'type': 'boolean'},
+            'debug_path': {'type': ['string', 'null']},
+            'timeout': {'type': 'integer'},
+        },
+    }
+
     def __init__(self):
         self.compress: bool = False
         self.compressed_path: Optional[str] = None
         self.clean_debug_path: bool = False
         self.debug_path: Optional[str] = None
         self.timeout: int = 20
+
+    def apply(self, new_config: dict) -> None:
+        validate(new_config, self.SCHEMA)
+        self.__dict__.update(new_config)
 
 
 conf = Configuration()

--- a/ixdiagnose/config.py
+++ b/ixdiagnose/config.py
@@ -1,5 +1,5 @@
 from jsonschema import validate
-from typing import Optional
+from typing import List, Optional
 
 
 class Configuration:
@@ -11,6 +11,7 @@ class Configuration:
             'compressed_path': {'type': ['string', 'null']},
             'clean_debug_path': {'type': 'boolean'},
             'debug_path': {'type': ['string', 'null']},
+            'exclude_plugins': {'type': 'array', 'items': {'type': 'string'}},
             'structured_data': {'type': 'boolean'},
             'timeout': {'type': 'integer'},
         },
@@ -21,6 +22,7 @@ class Configuration:
         self.compressed_path: Optional[str] = None
         self.clean_debug_path: bool = False
         self.debug_path: Optional[str] = None
+        self.exclude_plugins: List[str] = []
         self.structured_data: bool = False
         self.timeout: int = 20
 

--- a/ixdiagnose/plugin.py
+++ b/ixdiagnose/plugin.py
@@ -2,6 +2,7 @@ import concurrent.futures
 import os
 import traceback
 
+from .config import conf
 from .event import send_event
 from .plugins.factory import plugin_factory
 from .utils.formatter import dumps
@@ -12,10 +13,11 @@ def generate_plugins_debug(percentage: int = 0, total_percentage: int = 100) -> 
     os.makedirs(get_plugin_base_dir(), exist_ok=True)
     send_event(percentage + 1, 'Gathering plugins debug information')
 
-    plugin_percentage = total_percentage / len(plugin_factory.get_items())
+    to_execute_plugins = {k: v for k, v in plugin_factory.get_items().items() if k not in conf.exclude_plugins}
+    plugin_percentage = total_percentage / len(to_execute_plugins)
     with concurrent.futures.ProcessPoolExecutor(max_workers=3) as exc:
         futures = {
-            exc.submit(plugin.execute): plugin_name for plugin_name, plugin in plugin_factory.get_items().items()
+            exc.submit(plugin.execute): plugin_name for plugin_name, plugin in to_execute_plugins.items()
         }
         plugins_report = {}
         for future in concurrent.futures.as_completed(futures):

--- a/ixdiagnose/plugins/base.py
+++ b/ixdiagnose/plugins/base.py
@@ -4,6 +4,7 @@ import traceback
 
 from typing import List
 
+from ixdiagnose.config import conf
 from ixdiagnose.utils.formatter import dumps
 from ixdiagnose.utils.middleware import get_middleware_client
 from ixdiagnose.utils.paths import get_plugin_base_dir
@@ -32,7 +33,7 @@ class Plugin:
         return os.path.join(get_plugin_base_dir(), self.name)
 
     def metrics_to_execute(self):
-        return self.metrics + self.raw_metrics
+        return self.metrics + (self.serializable_metrics if conf.structured_data else self.raw_metrics)
 
     def execute_metrics(self) -> None:
         os.makedirs(self.output_dir, exist_ok=True)


### PR DESCRIPTION
## Context

We have `Configuration` class which held logic for setting user specified values or sane defaults which defined how `ixdiagnose` got executed. The same model has been extended to allow other configuration knobs which can be used to control behaviour of debug generation.

Motivation behind the singleton pattern is that the `conf` can be consumed directly when consuming `ixdiagnose` as a python library and the same can be consumed when CLI settings are applied making it generic enough to handle both cases.

Configuration knobs have been extended to allow for certain requests which were desired in the re-write of the debug generation tool.