### PR TITLE
NAS-121523 / 23.10 / Remove process pool executor when gathering plugins data

### DIFF
--- a/ixdiagnose/plugin.py
+++ b/ixdiagnose/plugin.py
@@ -1,4 +1,3 @@
-import concurrent.futures
 import os
 import traceback
 
@@ -15,28 +14,23 @@ def generate_plugins_debug(percentage: int = 0, total_percentage: int = 100) -> 
 
     to_execute_plugins = {k: v for k, v in plugin_factory.get_items().items() if k not in conf.exclude_plugins}
     plugin_percentage = total_percentage / len(to_execute_plugins)
-    with concurrent.futures.ProcessPoolExecutor(max_workers=3) as exc:
-        futures = {
-            exc.submit(plugin.execute): plugin_name for plugin_name, plugin in to_execute_plugins.items()
-        }
-        plugins_report = {}
-        for future in concurrent.futures.as_completed(futures):
-            plugin_name = futures[future]
-            try:
-                report = future.result()
-            except Exception as exc:
-                report = {
-                    'execution_time': None,
-                    'execution_error': str(exc),
-                    'execution_traceback': traceback.format_exc(),
-                }
-                description = f'Error gathering debug information for {plugin_name!r} plugin'
-            else:
-                description = f'Gathered debug information for {plugin_name!r} plugin'
+    plugins_report = {}
+    for plugin_name, plugin in to_execute_plugins.items():
+        try:
+            report = plugin.execute()
+        except Exception as exc:
+            report = {
+                'execution_time': None,
+                'execution_error': str(exc),
+                'execution_traceback': traceback.format_exc(),
+            }
+            description = f'Error gathering debug information for {plugin_name!r} plugin'
+        else:
+            description = f'Gathered debug information for {plugin_name!r} plugin'
 
-            plugins_report[plugin_name] = report
-            percentage += plugin_percentage
-            send_event(percentage, description)
+        plugins_report[plugin_name] = report
+        percentage += plugin_percentage
+        send_event(percentage, description)
 
     with open(os.path.join(get_plugin_base_dir(), 'report.json'), 'w') as f:
         f.write(dumps(plugins_report))


### PR DESCRIPTION
## Context

`conf` object is re-initialised in the process pool which results in various inconsistencies when executing plugins.
We could workaround it but after discussion with @yocalebo we decided to remove the process pool executor for now and re-visit this as required.