### PR TITLE
NAS-121554 / 23.10 / Add pytest coverage

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch: false

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -1,0 +1,31 @@
+name: Add pytest coverage to PR
+
+on:
+  pull_request:
+    types:
+      - 'synchronize'
+      - 'opened'
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  add-coverage:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/truenas/ixdiagnose:master
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Install dependencies
+      run: |
+        pip install -r requirements.txt
+        pip install pytest-cov
+        pip install -U .
+    - name: Run tests
+      run: pytest --cov-report xml --cov=ixdiagnose
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v2.1.0
+      with:
+        files: ./coverage.xml
+        token: ${{ secrets.CODECOV }}

--- a/ixdiagnose/test/pytest/unit/metrics/test_command_metric.py
+++ b/ixdiagnose/test/pytest/unit/metrics/test_command_metric.py
@@ -36,8 +36,7 @@ from subprocess import CompletedProcess
         'command_metric_output2.txt',
         False
     )
-]
-                         )
+])
 def test_command_metric(mocker, name, cmds, return_values, input_file, output_file, should_work):
     input_params = get_asset(input_file)
     output = get_asset(output_file)

--- a/ixdiagnose/test/pytest/unit/metrics/test_directory_tree_metric.py
+++ b/ixdiagnose/test/pytest/unit/metrics/test_directory_tree_metric.py
@@ -91,7 +91,7 @@ def test_directory_tree_metric(mocker, name, isdir, path, result, report, should
         assert reports != report
 
 
-@pytest.mark.parametrize('middlleware_response,results,reports', [
+@pytest.mark.parametrize('middleware_response,results,reports', [
     (
         MiddlewareResponse(
             result_key='filesystem_listdir',
@@ -167,8 +167,8 @@ def test_directory_tree_metric(mocker, name, isdir, path, result, report, should
         ],
     ),
 ])
-def test_get_results(mocker, middlleware_response, results, reports):
-    mocker.patch.object(MiddlewareCommand, 'execute', return_value=middlleware_response)
+def test_get_results(mocker, middleware_response, results, reports):
+    mocker.patch.object(MiddlewareCommand, 'execute', return_value=middleware_response)
     output, report = get_results('/etc/certificates')
     assert output == results
     assert report == reports

--- a/ixdiagnose/test/pytest/unit/metrics/test_metric.py
+++ b/ixdiagnose/test/pytest/unit/metrics/test_metric.py
@@ -1,0 +1,61 @@
+import pytest
+
+from ixdiagnose.plugins.metrics.base import Metric
+
+
+@pytest.mark.parametrize('context,data,should_work', [
+    (
+        {
+            'middleware_client': None,
+            'output_dir': '/root/debug_reports/ixdiagnose/plugins/iscsi'
+        },
+        (
+            [
+                {
+                    'endpoint': 'service.query',
+                    'error': None,
+                    'execution_time': 0.07165694236755371,
+                    'description': 'Query all system services with `query-filters` and `query-options`'
+                }
+            ],
+            {
+                'key': 'service',
+                'output': {
+                    'id': 7,
+                    'service': 'iscsitarget',
+                    'enable': True,
+                    'state': 'RUNNING',
+                    'pids': []
+                }
+            }
+        ),
+        False
+    ),
+    (
+        {
+            'middleware_client': None,
+            'output_dir': '/root/debug_reports/ixdiagnose/plugins/iscsi'
+        },
+        (
+            [
+                {
+                    'endpoint': 'service.query',
+                    'error': None,
+                    'execution_time': 0.07165694236755371,
+                    'description': 'Query all system services with `query-filters` and `query-options`'
+                }
+            ],
+            ''
+        ),
+        True
+    )
+])
+def test_metric_execute(mocker, context, data, should_work):
+    mocker.patch('ixdiagnose.plugins.metrics.base.Metric.initialize_context', return_value=None)
+    mocker.patch('ixdiagnose.plugins.metrics.base.Metric.execute_impl', return_value=data)
+    metric = Metric('iscsi')
+    if should_work:
+        assert metric.execute(context) == data
+    else:
+        with pytest.raises(AssertionError):
+            metric.execute(context)

--- a/ixdiagnose/test/pytest/unit/plugins/assets/smb_shares_output.txt
+++ b/ixdiagnose/test/pytest/unit/plugins/assets/smb_shares_output.txt
@@ -1,0 +1,23 @@
+[data]
+	vfs objects = streams_xattr shadow_copy_zfs acl_xattr zfs_core io_uring
+	ea support = False
+	path = /mnt/crave/data
+	tn:purpose = DEFAULT_SHARE
+	comment =
+	guest ok = False
+	fruit:time machine max size = 0
+	tn:path_suffix =
+	tn:home = False
+	read only = False
+	browseable = True
+	fruit:time machine = False
+	access based share enum = False
+	hosts allow =
+	hosts deny =
+	posix locking = False
+	kernel oplocks = False
+	smbd max xattr size = 2097152
+	tn:vuid =
+drwxrwxr-x+ 6 root root 7 Feb 13 05:42 /mnt/crave/data
+Filesystem     Type 1K-blocks   Used Available Use% Mounted on
+crave/data     zfs    3873152 380160   3492992  10% /mnt/crave/data

--- a/ixdiagnose/test/pytest/unit/plugins/test_base_plugin.py
+++ b/ixdiagnose/test/pytest/unit/plugins/test_base_plugin.py
@@ -1,0 +1,66 @@
+import pytest
+
+from ixdiagnose.plugins.metrics.middleware import MiddlewareClientMetric
+from ixdiagnose.plugins.base import Plugin
+from ixdiagnose.utils.middleware import MiddlewareCommand
+
+
+@pytest.mark.parametrize('metrics_to_execute,metric_output,metric_report', [
+    (
+        [
+            MiddlewareClientMetric('services', [MiddlewareCommand('service.query', result_key='services_status')]),
+        ],
+        {
+            'key': 'services_status',
+            'output': [
+                {
+                    'id': 1,
+                    'service': 'nfs',
+                    'enable': True,
+                    'state': 'STOPPED',
+                    'pids': []
+                },
+                {
+                    'id': 2,
+                    'service': 'snmp',
+                    'enable': False,
+                    'state': 'STOPPED',
+                    'pids': []
+                },
+                {
+                    'id': 3,
+                    'service': 'ssh',
+                    'enable': True,
+                    'state': 'RUNNING',
+                    'pids': [
+                        2602
+                    ]
+                },
+            ]
+        },
+        [
+            {
+                'endpoint': 'service.query',
+                'error': None,
+                'execution_time': 0.6482527256011963,
+                'description': 'Query all system services with `query-filters` and `query-options`.\n\n'
+                               'Supports the following extra options:\n'
+                               '`include_state` - performance optimization to avoid getting service state.\n'
+                               'defaults to True.'
+            }
+        ]
+    )
+])
+def test_ecexute_impl(mocker, metrics_to_execute, metric_output, metric_report):
+    mock_client = mocker.MagicMock()
+    context = {'middleware_client': mock_client, 'output_dir': '/root/debug_reports/ixdiagnose/plugins/services'}
+    mocker.patch('ixdiagnose.plugins.base.Plugin.metrics_to_execute', return_value=metrics_to_execute)
+    mocker.patch('os.path.join', return_value='/root/debug_reports/ixdiagnose/plugins/services')
+    mock_obj = mocker.mock_open()
+    mock_file = mocker.patch('builtins.open', mock_obj)
+    mock_file.write = metric_output
+    with pytest.raises(AssertionError):
+        Plugin()
+    Plugin.name = 'services'
+    plugin = Plugin()
+    assert plugin.execute_impl(context) is None

--- a/ixdiagnose/test/pytest/unit/plugins/test_base_plugin.py
+++ b/ixdiagnose/test/pytest/unit/plugins/test_base_plugin.py
@@ -1,7 +1,7 @@
 import pytest
 
-from ixdiagnose.plugins.metrics.middleware import MiddlewareClientMetric
 from ixdiagnose.plugins.base import Plugin
+from ixdiagnose.plugins.metrics.middleware import MiddlewareClientMetric
 from ixdiagnose.utils.middleware import MiddlewareCommand
 
 

--- a/ixdiagnose/test/pytest/unit/plugins/test_base_plugin.py
+++ b/ixdiagnose/test/pytest/unit/plugins/test_base_plugin.py
@@ -51,7 +51,7 @@ from ixdiagnose.utils.middleware import MiddlewareCommand
         ]
     )
 ])
-def test_ecexute_impl(mocker, metrics_to_execute, metric_output, metric_report):
+def test_execute_impl(mocker, metrics_to_execute, metric_output, metric_report):
     mock_client = mocker.MagicMock()
     context = {'middleware_client': mock_client, 'output_dir': '/root/debug_reports/ixdiagnose/plugins/services'}
     mocker.patch('ixdiagnose.plugins.base.Plugin.metrics_to_execute', return_value=metrics_to_execute)
@@ -60,7 +60,9 @@ def test_ecexute_impl(mocker, metrics_to_execute, metric_output, metric_report):
     mock_file = mocker.patch('builtins.open', mock_obj)
     mock_file.write = metric_output
     with pytest.raises(AssertionError):
+        # Test to ensure name is set
         Plugin()
+
     Plugin.name = 'services'
     plugin = Plugin()
     assert plugin.execute_impl(context) is None

--- a/ixdiagnose/test/pytest/unit/plugins/test_smart_output.py
+++ b/ixdiagnose/test/pytest/unit/plugins/test_smart_output.py
@@ -1,0 +1,56 @@
+import pytest
+from subprocess import CompletedProcess
+
+from ixdiagnose.plugins.smart import smart_output
+
+
+@pytest.mark.parametrize('run_output', [
+    [
+        CompletedProcess(
+            args=(
+                    'lsblk', '-ndo', 'name', '-I', '8,65,66,67,68,69,70,71,128,129,130,131,132,133,134,135,254,259'
+            ),
+            returncode=0,
+            stdout='vda\nvdb\nvdc\n',
+            stderr=''
+        ),
+        CompletedProcess(
+            args=(
+                    'smartctl', '-a', '/dev/vda'
+            ),
+            returncode=1,
+            stdout='smartctl 7.2 2020-12-30 r5155 [x86_64-linux-5.15.79+truenas] (local build)\n'
+                   'Copyright (C) 2002-20, Bruce Allen, Christian Franke, www.smartmontools.org\n\n'
+                   '/dev/vda: Unable to detect device type\nPlease specify device type with the -d option.\n\n'
+                   'Use smartctl -h to get a usage summary\n\n',
+            stderr=''
+        ),
+        CompletedProcess(
+            args=(
+                    'smartctl', '-a', '/dev/vdb'
+            ),
+            returncode=1,
+            stdout='smartctl 7.2 2020-12-30 r5155 [x86_64-linux-5.15.79+truenas] (local build)\n'
+                   'Copyright (C) 2002-20, Bruce Allen, Christian Franke, www.smartmontools.org\n\n'
+                   '/dev/vdb: Unable to detect device type\nPlease specify device type with the -d option.\n\n'
+                   'Use smartctl -h to get a usage summary\n\n',
+            stderr=''
+        ),
+        CompletedProcess(
+            args=(
+                    'smartctl', '-a', '/dev/vdc'
+            ),
+            returncode=1,
+            stdout='smartctl 7.2 2020-12-30 r5155 [x86_64-linux-5.15.79+truenas] (local build)\n'
+                   'Copyright (C) 2002-20, Bruce Allen, Christian Franke, www.smartmontools.org\n\n'
+                   '/dev/vdc: Unable to detect device type\n'
+                   'Please specify device type with the -d option.\n\n'
+                   'Use smartctl -h to get a usage summary\n\n',
+            stderr=''
+        ),
+    ]
+])
+def test_smart_output(mocker, run_output):
+    client = mocker.MagicMock()
+    mocker.patch('ixdiagnose.plugins.smart.run', side_effect=run_output)
+    assert isinstance(smart_output(client, {'serializable': False}), str)

--- a/ixdiagnose/test/pytest/unit/plugins/test_smart_output.py
+++ b/ixdiagnose/test/pytest/unit/plugins/test_smart_output.py
@@ -8,7 +8,7 @@ from ixdiagnose.plugins.smart import smart_output
     [
         CompletedProcess(
             args=(
-                    'lsblk', '-ndo', 'name', '-I', '8,65,66,67,68,69,70,71,128,129,130,131,132,133,134,135,254,259'
+                'lsblk', '-ndo', 'name', '-I', '8,65,66,67,68,69,70,71,128,129,130,131,132,133,134,135,254,259'
             ),
             returncode=0,
             stdout='vda\nvdb\nvdc\n',
@@ -16,7 +16,7 @@ from ixdiagnose.plugins.smart import smart_output
         ),
         CompletedProcess(
             args=(
-                    'smartctl', '-a', '/dev/vda'
+                'smartctl', '-a', '/dev/vda'
             ),
             returncode=1,
             stdout='smartctl 7.2 2020-12-30 r5155 [x86_64-linux-5.15.79+truenas] (local build)\n'
@@ -27,7 +27,7 @@ from ixdiagnose.plugins.smart import smart_output
         ),
         CompletedProcess(
             args=(
-                    'smartctl', '-a', '/dev/vdb'
+                'smartctl', '-a', '/dev/vdb'
             ),
             returncode=1,
             stdout='smartctl 7.2 2020-12-30 r5155 [x86_64-linux-5.15.79+truenas] (local build)\n'
@@ -38,7 +38,7 @@ from ixdiagnose.plugins.smart import smart_output
         ),
         CompletedProcess(
             args=(
-                    'smartctl', '-a', '/dev/vdc'
+                'smartctl', '-a', '/dev/vdc'
             ),
             returncode=1,
             stdout='smartctl 7.2 2020-12-30 r5155 [x86_64-linux-5.15.79+truenas] (local build)\n'
@@ -53,4 +53,4 @@ from ixdiagnose.plugins.smart import smart_output
 def test_smart_output(mocker, run_output):
     client = mocker.MagicMock()
     mocker.patch('ixdiagnose.plugins.smart.run', side_effect=run_output)
-    assert isinstance(smart_output(client, {'serializable': False}), str)
+    assert isinstance(smart_output(client, {'serializable': False}), str) is True

--- a/ixdiagnose/test/pytest/unit/plugins/test_smart_output.py
+++ b/ixdiagnose/test/pytest/unit/plugins/test_smart_output.py
@@ -1,7 +1,7 @@
 import pytest
-from subprocess import CompletedProcess
 
 from ixdiagnose.plugins.smart import smart_output
+from subprocess import CompletedProcess
 
 
 @pytest.mark.parametrize('run_output', [

--- a/ixdiagnose/test/pytest/unit/plugins/test_smb_shares.py
+++ b/ixdiagnose/test/pytest/unit/plugins/test_smb_shares.py
@@ -80,5 +80,5 @@ def test_get_smb_shares(mocker, middleware_return_values):
         stderr=''
     ))
     result = get_smb_shares(mock_client, None)
-    assert isinstance(result, str)
+    assert isinstance(result, str) is True
     assert result == output

--- a/ixdiagnose/test/pytest/unit/plugins/test_smb_shares.py
+++ b/ixdiagnose/test/pytest/unit/plugins/test_smb_shares.py
@@ -1,8 +1,8 @@
 import pytest
-from subprocess import CompletedProcess
 
 from ixdiagnose.plugins.smb import get_smb_shares
 from ixdiagnose.test.pytest.unit.utils import get_asset
+from subprocess import CompletedProcess
 
 
 @pytest.mark.parametrize('middleware_return_values', [

--- a/ixdiagnose/test/pytest/unit/plugins/test_smb_shares.py
+++ b/ixdiagnose/test/pytest/unit/plugins/test_smb_shares.py
@@ -1,0 +1,84 @@
+import pytest
+from subprocess import CompletedProcess
+
+from ixdiagnose.plugins.smb import get_smb_shares
+from ixdiagnose.test.pytest.unit.utils import get_asset
+
+
+@pytest.mark.parametrize('middleware_return_values', [
+    [
+        [
+            {
+                'id': 3,
+                'purpose': 'DEFAULT_SHARE',
+                'path': '/mnt/crave/data',
+                'path_suffix': '',
+                'home': False,
+                'name': 'data',
+                'comment': '',
+                'ro': False,
+                'browsable': True,
+                'recyclebin': False,
+                'guestok': False,
+                'hostsallow': [],
+                'hostsdeny': [],
+                'auxsmbconf': '',
+                'aapl_name_mangling': False,
+                'abe': False,
+                'acl': True,
+                'durablehandle': True,
+                'streams': True,
+                'timemachine': False,
+                'timemachine_quota': 0,
+                'vuid': '',
+                'shadowcopy': True,
+                'fsrvp': False,
+                'enabled': True,
+                'cluster_volname': '',
+                'afp': False,
+                'path_local': '/mnt/crave/data',
+                'locked': False
+            },
+        ],
+        {
+            'properties': {
+                'mountpoint': {
+                    'parsed': '/mnt/crave/data',
+                    'rawvalue': '/mnt/crave/data',
+                    'value': '/mnt/crave/data',
+                    'source': 'DEFAULT',
+                    'source_info': None
+                },
+                'acltype': {
+                    'parsed': 'posix',
+                    'rawvalue': 'posix',
+                    'value': 'posix',
+                    'source': 'LOCAL',
+                    'source_info': None
+                }
+            },
+            'id': 'crave/data',
+            'type': 'FILESYSTEM',
+            'name': 'crave/data',
+            'pool': 'crave',
+            'encrypted': False,
+            'encryption_root': None,
+            'key_loaded': False,
+            'children': []
+        }
+    ]
+])
+def test_get_smb_shares(mocker, middleware_return_values):
+    output = get_asset('smb_shares_output.txt')
+    mock_client = mocker.MagicMock(side_effect=middleware_return_values)
+    mocker.patch('ixdiagnose.plugins.smb.run', return_value=CompletedProcess(
+        args=(
+            'net conf showshare data\nls -ld /mnt/crave/data\ndf -T /mnt/crave/data\n',
+        ),
+        returncode=0,
+        stdout=output,
+        stderr=''
+    ))
+    result = get_smb_shares(mock_client, None)
+    assert isinstance(result, str)
+    assert result == output


### PR DESCRIPTION
## Context

Pytest coverage has been added to expand the scope of the testing in place for ixdiagnose and more tests have been added based on the report generated by pytest coverage to cover areas which lacked enough tests and push the coverage to 90%+.