### PR TITLE
NAS-121572 / 23.10 / Add pytest dependency to debian package

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -5,3 +5,5 @@ export PYBUILD_NAME=ixdiagnose
 
 %:
 	dh $@ --with python3 --buildsystem=pybuild
+
+override_dh_auto_test:


### PR DESCRIPTION
## Problem

Test suite is executed when building debian package in our scale builder and we were missing pytest build time dependencies.

## Solution

Add required pytest python debian packages as build time dependencies for the scale builder to successfully build ixdiagnose.