### PR TITLE
NAS-122847 / 23.10 / Fix integration test when metric fails

### DIFF
--- a/ixdiagnose/test/pytest/integration/test_plugins.py
+++ b/ixdiagnose/test/pytest/integration/test_plugins.py
@@ -19,7 +19,7 @@ PLUGINS_REPORT_SCHEMA = {
         'metric_report': {
             'anyOf': [
                 {
-                    'type': 'array',
+                    'type': ['array', 'null'],
                     'items': {
                         'type': 'object',
                         'properties': {
@@ -33,7 +33,7 @@ PLUGINS_REPORT_SCHEMA = {
                     }
                 },
                 {
-                    'type': 'object',
+                    'type': ['object', 'null'],
                     'properties': {
                         'error': {'type': ['string', 'null']}
                     }


### PR DESCRIPTION
## Problem

Metrics can fail for various reasons and that will result in `metric_report` attribute being `null`.
We still get the complete traceback for the issue
```
  "time_info": {
    "execution_time": 0.005153656005859375,
    "metric_report": null,
    "metric_execution_error": "[Errno 2] No such file or directory: 'chronycs'",
    "metric_execution_traceback": "Traceback (most recent call last):\n  File \"/root/ixdiagnose/ixdiagnose/plugins/base.py\", line 57, in execute_impl\n    metric_report, metric_output = metric.execute(context)  # execution mechanism TBD\n                                   ^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/root/ixdiagnose/ixdiagnose/plugins/metrics/base.py\", line 32, in execute\n    data = self.execute_impl()\n           ^^^^^^^^^^^^^^^^^^^\n  File \"/root/ixdiagnose/ixdiagnose/plugins/metrics/command.py\", line 46, in execute_impl\n    cp = cmd.execute()\n         ^^^^^^^^^^^^^\n  File \"/root/ixdiagnose/ixdiagnose/utils/command.py\", line 22, in execute\n    cp = run(self.command, check=False, env=self.env)\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/root/ixdiagnose/ixdiagnose/utils/run.py\", line 17, in run\n    proc = subprocess.Popen(\n           ^^^^^^^^^^^^^^^^^\n  File \"/usr/lib/python3.11/subprocess.py\", line 1024, in __init__\n    self._execute_child(args, executable, preexec_fn, close_fds,\n  File \"/usr/lib/python3.11/subprocess.py\", line 1901, in _execute_child\n    raise child_exception_type(errno_num, err_msg, err_filename)\nFileNotFoundError: [Errno 2] No such file or directory: 'chronycs'\n"
  },
```
However this resulted in the integration test failing as it did not account for the attribute being `null`.

## Solution

Update the plugin report schema to account for the fact that `metric_report` can be `null`.