### PR TITLE
NAS-122848 / 23.10 / Use middleware image for github CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,14 @@ jobs:
   build-deb:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/truenas/ixdiagnose:master
+      image: ghcr.io/truenas/middleware:master
 
     steps:
       - name: Checkout
         uses: actions/checkout@v1
+
+      - name: Setup apt
+        run: chmod +x /usr/bin/apt* && chmod +x /usr/bin/dpkg
 
       - name: Install Dependencies
         run: apt update && apt install -y debhelper-compat dh-python python3-dev python3-setuptools devscripts

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,23 +1,24 @@
 name: integration_tests
 
-on:
-  pull_request:
-    types:
-      - 'synchronize'
-      - 'opened'
+on: [push]
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/truenas/ixdiagnose:master
+      image: ghcr.io/truenas/middleware:master
 
     steps:
     - uses: actions/checkout@v2
+    - name: Setup dependencies
+      run: |
+        /usr/bin/install-dev-tools
+
     - name: Deps
       run: |
-        pip install -r requirements.txt
-        pip install -U .
+        pip install --break-system-packages -r requirements.txt
+        pip install --break-system-packages -U .
+
     - name: Running test
       run: pytest -v ixdiagnose/test/pytest/integration/

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,23 +1,24 @@
 name: unit_tests
 
-on:
-  pull_request:
-    types:
-      - 'synchronize'
-      - 'opened'
+on: [push]
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/truenas/ixdiagnose:master
+      image: ghcr.io/truenas/middleware:master
 
     steps:
     - uses: actions/checkout@v2
+    - name: Setup dependencies
+      run: |
+        /usr/bin/install-dev-tools
+
     - name: Deps
       run: |
-        pip install -r requirements.txt
-        pip install -U .
+        pip install --break-system-packages -r requirements.txt
+        pip install --break-system-packages -U .
+
     - name: Running test
       run: pytest -v ixdiagnose/test/pytest/unit/


### PR DESCRIPTION
## Context

The image `ghcr.io/truenas/ixdiagnose:master` is not being updated regularly which can result in packages missing and CI failing.
So we should be using `ghcr.io/truenas/middleware:master` instead and we are already installing the checked out ixdiagnose changes so that suffices and we don't need to maintain an updated docker image of `truenas/ixdiagnose`.