### PR TITLE
Allow waiting for jobs to complete

### DIFF
--- a/ixdiagnose/utils/middleware.py
+++ b/ixdiagnose/utils/middleware.py
@@ -26,12 +26,13 @@ class MiddlewareResponse:
 class MiddlewareCommand:
     def __init__(
         self, endpoint: str, api_payload: Optional[List] = None, format_output: Optional[Callable] = None,
-        result_key: Optional[str] = None
+        result_key: Optional[str] = None, job: bool = False,
     ):
         self.endpoint: str = endpoint
         self.overridden_format_output: Optional[Callable] = format_output
         self.payload: List = api_payload or []
         self.result_key: str = result_key or self.endpoint.replace('.', '_')
+        self.job: bool = job
 
     def format_output(self, output: Any) -> Any:
         return self.overridden_format_output(output) if self.overridden_format_output else output
@@ -40,10 +41,10 @@ class MiddlewareCommand:
         response = MiddlewareResponse(result_key=self.result_key)
         try:
             if middleware_client:
-                response.output = middleware_client.call(self.endpoint, *self.payload)
+                response.output = middleware_client.call(self.endpoint, *self.payload, job=self.job)
             else:
                 with get_middleware_client() as client:
-                    response.output = client.call(self.endpoint, *self.payload)
+                    response.output = client.call(self.endpoint, *self.payload, job=self.job)
         except Exception as e:
             response.error = str(e)
         else:


### PR DESCRIPTION
## Context

A new parameter has been added to `MiddlewareCommand` to allow waiting for a job to complete so we get the job's endpoints output and not the job number.