### PR TITLE
Get reporting debug

### DIFF
--- a/ixdiagnose/plugins/factory.py
+++ b/ixdiagnose/plugins/factory.py
@@ -12,6 +12,7 @@ from .ldap import LDAP
 from .network import Network
 from .nfs import NFS
 from .replication import Replication
+from .reporting import Reporting
 from .services import Services
 from .smart import SMART
 from .smb import SMB
@@ -36,6 +37,7 @@ for plugin in [
     Network,
     NFS,
     Replication,
+    Reporting,
     Services,
     SMART,
     SMB,

--- a/ixdiagnose/plugins/reporting.py
+++ b/ixdiagnose/plugins/reporting.py
@@ -1,0 +1,16 @@
+from ixdiagnose.utils.middleware import MiddlewareCommand
+
+from .base import Plugin
+from .metrics import MiddlewareClientMetric
+from .prerequisites import ServiceRunningPrerequisite
+
+
+class Reporting(Plugin):
+    name = 'reporting'
+    metrics = [
+        MiddlewareClientMetric(
+            'graphs', [MiddlewareCommand(
+                'reporting.netdata_graphs', result_key='all_graphs',
+            )], prerequisites=[ServiceRunningPrerequisite('netdata')],
+        ),
+    ]


### PR DESCRIPTION
## Context

It is useful to know what graphs are being recognized by netdata/reporting plugin and what identifiers it is reporting for various graphs so we can efficiently diagnose if there is a bug/mistake on middleware side.