### PR TITLE
NAS-123566 / 24.04 / Don't get zfs snapshots details

### DIFF
--- a/ixdiagnose/plugins/zfs.py
+++ b/ixdiagnose/plugins/zfs.py
@@ -31,7 +31,10 @@ def zfs_getacl_impl(dataset_name: str, props_dict: dict) -> str:
 
 
 def resource_output(client: MiddlewareClient, resource_type: str) -> str:
-    cp = run([resource_type, 'get', 'all'], check=False)
+    if resource_type == 'zfs':
+        cp = run(['zfs', 'get', 'all', '-t', 'filesystem'], check=False)
+    else:
+        cp = run([resource_type, 'get', 'all'], check=False)
     if cp.returncode:
         return f'Failed to retrieve {resource_type!r} resources: {cp.stderr}'
 


### PR DESCRIPTION
## Problem

Currently, our method for retrieving ZFS dataset properties indiscriminately fetches data for both datasets and their associated snapshots. In environments with significant snapshot usage, this approach can result in retrieving vast amounts of data. Given that users can possess thousands of snapshots, this operation becomes highly expensive and can lead to considerable performance degradation.

## Solution

We've implemented a custom script that refines the data retrieval process. This script is tailored to concentrate solely on datasets, effectively excluding snapshots from the data retrieval process. By doing so, we significantly reduce the overhead and ensure a more efficient and faster operation, especially in ZFS setups with a high number of snapshots.
