### PR TITLE
NAS-123567 / 23.10 / Fix dataset_list header (by Qubad786)

### DIFF
--- a/ixdiagnose/plugins/zfs.py
+++ b/ixdiagnose/plugins/zfs.py
@@ -106,7 +106,7 @@ class ZFS(Plugin):
     metrics = [
         CommandMetric(
             'dataset_list', [
-                Command(['zfs', 'list', '-ro', 'space,refer,mountpoint'], 'ZFS Pool(s)', serializable=False),
+                Command(['zfs', 'list', '-ro', 'space,refer,mountpoint'], 'ZFS Dataset(s)', serializable=False),
             ]
         ),
         CommandMetric(


### PR DESCRIPTION
## Problem

`dataset_list.txt` had an incorrect header saying that the content refers to ZFS pools whereas it in reality points to ZFS datasets.

## Solution

Update the header to appropriately refer to data which it points to.

Original PR: https://github.com/truenas/ixdiagnose/pull/38
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123567