### PR TITLE
NAS-123590 / 23.10 / add VMPrerequisite to prevent log spam (by yocalebo)

### DIFF
--- a/ixdiagnose/plugins/prerequisites/__init__.py
+++ b/ixdiagnose/plugins/prerequisites/__init__.py
@@ -1,11 +1,13 @@
 from .active_directory import ActiveDirectoryStatePrerequisite, LDAPStatePrerequisite
 from .base import Prerequisite
 from .service import ServiceRunningPrerequisite
+from .vm import VMPrerequisite
 
 
 __all__ = [
     'ActiveDirectoryStatePrerequisite',
     'LDAPStatePrerequisite',
+    'VMPrerequisite',
     'Prerequisite',
     'ServiceRunningPrerequisite',
 ]

--- a/ixdiagnose/plugins/prerequisites/vm.py
+++ b/ixdiagnose/plugins/prerequisites/vm.py
@@ -1,0 +1,12 @@
+from ixdiagnose.utils.middleware import MiddlewareCommand
+
+from .base import Prerequisite
+
+
+class VMPrerequisite(Prerequisite):
+
+    def evaluate_impl(self) -> bool:
+        return MiddlewareCommand('vm.supports_virtualization').execute()
+
+    def __str__(self):
+        return f'{self.cache_key!r} vm service state check'

--- a/ixdiagnose/plugins/vm.py
+++ b/ixdiagnose/plugins/vm.py
@@ -2,21 +2,30 @@ from ixdiagnose.utils.middleware import MiddlewareCommand
 
 from .base import Plugin
 from .metrics import FileMetric, MiddlewareClientMetric
+from .prerequisites import VMPrerequisite
 
 
 class VM(Plugin):
     name = 'vm'
     metrics = [
-        FileMetric('haproxy', '/etc/haproxy/haproxy.cfg', extension='.cfg'),
+        FileMetric('haproxy', '/etc/haproxy/haproxy.cfg', extension='.cfg', prerequisites=[VMPrerequisite()]),
         MiddlewareClientMetric(
             'gpu', [MiddlewareCommand('device.get_gpus', result_key='gpus')],
+            prerequisites=[VMPrerequisite()]
         ),
         MiddlewareClientMetric(
             'passthrough_choices', [
                 MiddlewareCommand('vm.device.usb_passthrough_choices', result_key='usb_passthrough_choices'),
                 MiddlewareCommand('vm.device.passthrough_device_choices', result_key='passthrough_device_choices'),
             ],
+            prerequisites=[VMPrerequisite()]
         ),
-        MiddlewareClientMetric('vms', [MiddlewareCommand('vm.query', result_key='vms')]),
-        MiddlewareClientMetric('vm_devices', [MiddlewareCommand('vm.device.query', result_key='devices')]),
+        MiddlewareClientMetric(
+            'vms', [MiddlewareCommand('vm.query', result_key='vms')],
+            prerequisites=[VMPrerequisite()]
+        ),
+        MiddlewareClientMetric(
+            'vm_devices', [MiddlewareCommand('vm.device.query', result_key='devices')],
+            prerequisites=[VMPrerequisite()]
+        ),
     ]


### PR DESCRIPTION
Our VM plugin is designed in such a way that calling essentially any endpoint will produce log spam in middlewared.log
```
[2023/08/17 04:46:41] (ERROR) middlewared.wait_for_libvirtd():33 - Failed to setup libvirt
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/middlewared/plugins/vm/lifecycle.py", line 25, in wait_for_libvirtd
    self._system_supports_virtualization()
  File "/usr/lib/python3/dist-packages/middlewared/plugins/vm/connection.py", line 61, in _system_supports_virtualization
    raise CallError('This system does not support virtualization.')
middlewared.service_exception.CallError: [EFAULT] This system does not support virtualization.
```

This adds a prerequisite so that the VM plugin doesn't try and run any of these commands unless the host supports it.

Original PR: https://github.com/truenas/ixdiagnose/pull/46
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123590