### PR TITLE
NAS-123595 / 24.04 / Fix VMPrerequisite

### DIFF
--- a/ixdiagnose/plugins/prerequisites/vm.py
+++ b/ixdiagnose/plugins/prerequisites/vm.py
@@ -6,7 +6,7 @@ from .base import Prerequisite
 class VMPrerequisite(Prerequisite):
 
     def evaluate_impl(self) -> bool:
-        return MiddlewareCommand('vm.supports_virtualization').execute()
+        return MiddlewareCommand('vm.supports_virtualization').execute().output
 
     def __str__(self):
         return f'{self.cache_key!r} vm service state check'


### PR DESCRIPTION
## Problem

Function `evaluate_impl` returns `bool` but in VM prerequisite it is returning `MiddlewareResponse` object which will always evaluate to true.

## Solution

Properly reference the output received from middleware for VMs being supported.