### PR TITLE
NAS-123827 / 24.04 / add core.get_jobs to plugins

### DIFF
--- a/ixdiagnose/plugins/factory.py
+++ b/ixdiagnose/plugins/factory.py
@@ -12,6 +12,7 @@ from .hardware import Hardware
 from .initshutdown_scripts import InitShutDownScripts
 from .ipmi import IPMI
 from .iscsi import ISCSI
+from .jobs import CoreGetJobs
 from .kubernetes import Kubernetes
 from .ldap import LDAP
 from .network import Network
@@ -43,6 +44,7 @@ for plugin in [
     InitShutDownScripts,
     IPMI,
     ISCSI,
+    CoreGetJobs,
     Kubernetes,
     LDAP,
     Network,

--- a/ixdiagnose/plugins/jobs.py
+++ b/ixdiagnose/plugins/jobs.py
@@ -1,0 +1,11 @@
+from ixdiagnose.utils.middleware import MiddlewareCommand
+
+from .base import Plugin
+from .metrics import MiddlewareClientMetric
+
+
+class CoreGetJobs(Plugin):
+    name = 'jobs'
+    metrics = [
+        MiddlewareClientMetric('jobs', [MiddlewareCommand('core.get_jobs')]),
+    ]


### PR DESCRIPTION
This is pertinent for gathering collateral, for example, from our "tasks" and their respective results.