### PR TITLE
NAS-123827 / 23.10 / add core.get_jobs to plugins (by yocalebo)

### DIFF
--- a/ixdiagnose/plugins/factory.py
+++ b/ixdiagnose/plugins/factory.py
@@ -12,6 +12,7 @@ from .hardware import Hardware
 from .initshutdown_scripts import InitShutDownScripts
 from .ipmi import IPMI
 from .iscsi import ISCSI
+from .jobs import CoreGetJobs
 from .kubernetes import Kubernetes
 from .ldap import LDAP
 from .network import Network
@@ -43,6 +44,7 @@ for plugin in [
     InitShutDownScripts,
     IPMI,
     ISCSI,
+    CoreGetJobs,
     Kubernetes,
     LDAP,
     Network,

--- a/ixdiagnose/plugins/jobs.py
+++ b/ixdiagnose/plugins/jobs.py
@@ -1,0 +1,11 @@
+from ixdiagnose.utils.middleware import MiddlewareCommand
+
+from .base import Plugin
+from .metrics import MiddlewareClientMetric
+
+
+class CoreGetJobs(Plugin):
+    name = 'jobs'
+    metrics = [
+        MiddlewareClientMetric('jobs', [MiddlewareCommand('core.get_jobs')]),
+    ]


### PR DESCRIPTION
This is pertinent for gathering collateral, for example, from our "tasks" and their respective results.

Original PR: https://github.com/truenas/ixdiagnose/pull/59
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123827