### PR TITLE
NAS-124274 / 24.04 / add 2nd -s to show interface errors

### DIFF
--- a/ixdiagnose/plugins/network.py
+++ b/ixdiagnose/plugins/network.py
@@ -53,6 +53,6 @@ class Network(Plugin):
                 Command(['ip', '-j', 'rule', 'list'], 'ip_rules'),
             ]
         ),
-        CommandMetric('interface_statistics', [Command(['ip', '-j', '-s', 'addr'], 'Interface Statistics')]),
+        CommandMetric('interface_statistics', [Command(['ip', '-j', '-s', '-s', 'addr'], 'Interface Statistics')]),
         CommandMetric('nft_rules', [Command(['nft', '-j', '-a', 'list', 'ruleset'], 'NFTables rulesets')]),
     ]


### PR DESCRIPTION
Adding a 2nd `-s` also reports the error statistics for the network interfaces. This has proven to be useful information on a customer system.