### PR TITLE
NAS-124407 / 23.10 / Add text file with number of NFS clients by type (by mgrimesix)

### DIFF
--- a/ixdiagnose/plugins/nfs.py
+++ b/ixdiagnose/plugins/nfs.py
@@ -18,7 +18,7 @@ def nfs_client_count_by_type(client: MiddlewareClient, context: Any) -> str:
     output += f'{"NFSv3":^10}{"NFSv4.0":^10}{"NFSv4.1":^10}{"NFSv4.2":^10}\n'
     output += f'{"-----":^10}{"-------":^10}{"-------":^10}{"-------":^10}\n'
     output += f'{len(num_nfs3):^10}'
-    output += f'{nfs4_ver_info.count(0):^10}{nfs4_ver_info.count(1):^10}{nfs4_ver_info.count(2):^10}'
+    output += f'{nfs4_ver_info.count(0):^10}{nfs4_ver_info.count(1):^10}{nfs4_ver_info.count(2):^10}\n'
 
     return output
 

--- a/ixdiagnose/plugins/nfs.py
+++ b/ixdiagnose/plugins/nfs.py
@@ -13,11 +13,12 @@ def nfs_client_count_by_type(client: MiddlewareClient, context: Any) -> str:
     nfs4_ver_info = [x["info"]["minor version"] for x in nfs4_clnt_info]
 
     title = 'Number of NFS clients'
-    output = f'{"=" * (len(title) + 5)}\n  {title}\n{"=" * (len(title) + 5)}\n\n'
-    output += f'NFSv3:   {len(num_nfs3)}\n'
-    output += f'NFSv4.2: {nfs4_ver_info.count(2)}\n'
-    output += f'NFSv4.1: {nfs4_ver_info.count(1)}\n'
-    output += f'NFSv4.0: {nfs4_ver_info.count(0)}\n'
+    sep = '-----------------------------'
+    output = f'{sep}\n{title:^29}\n{sep}\n\n'
+    output += f'{"NFSv3":^10}{"NFSv4.0":^10}{"NFSv4.1":^10}{"NFSv4.2":^10}\n'
+    output += f'{"-----":^10}{"-------":^10}{"-------":^10}{"-------":^10}\n'
+    output += f'{len(num_nfs3):^10}'
+    output += f'{nfs4_ver_info.count(0):^10}{nfs4_ver_info.count(1):^10}{nfs4_ver_info.count(2):^10}'
 
     return output
 

--- a/ixdiagnose/plugins/nfs.py
+++ b/ixdiagnose/plugins/nfs.py
@@ -1,9 +1,25 @@
 from ixdiagnose.utils.command import Command
-from ixdiagnose.utils.middleware import MiddlewareCommand
+from ixdiagnose.utils.middleware import MiddlewareClient, MiddlewareCommand
+from typing import Any
 
 from .base import Plugin
-from .metrics import CommandMetric, FileMetric, MiddlewareClientMetric
+from .metrics import CommandMetric, FileMetric, MiddlewareClientMetric, PythonMetric
 from .prerequisites import ServiceRunningPrerequisite
+
+
+def nfs_client_count_by_type(client: MiddlewareClient, context: Any) -> str:
+    num_nfs3 = client.call('nfs.get_nfs3_clients')
+    nfs4_clnt_info = client.call('nfs.get_nfs4_clients')
+    nfs4_ver_info = [x["info"]["minor version"] for x in nfs4_clnt_info]
+
+    title = 'Number of NFS clients'
+    output = f'{"=" * (len(title) + 5)}\n  {title}\n{"=" * (len(title) + 5)}\n\n'
+    output += f'NFSv3:   {len(num_nfs3)}\n'
+    output += f'NFSv4.2: {nfs4_ver_info.count(2)}\n'
+    output += f'NFSv4.1: {nfs4_ver_info.count(1)}\n'
+    output += f'NFSv4.0: {nfs4_ver_info.count(0)}\n'
+
+    return output
 
 
 class NFS(Plugin):
@@ -39,4 +55,5 @@ class NFS(Plugin):
             MiddlewareCommand('nfs.config'),
             MiddlewareCommand('sharing.nfs.query'),
         ]),
+        PythonMetric('nfs-client-counts', nfs_client_count_by_type, serializable=False),
     ]


### PR DESCRIPTION
Add a text file, nfs-client-counts.txt, which displays the number of current NFS clients by type.
The types are: NFSv3, NFSv4.2, NFSv4.1 and NFS4.0

Original PR: https://github.com/truenas/ixdiagnose/pull/83
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124407