### PR TITLE
NAS-124262 / 24.04 / Remove haproxy from ixdiagnose

### DIFF
--- a/ixdiagnose/plugins/vm.py
+++ b/ixdiagnose/plugins/vm.py
@@ -1,14 +1,13 @@
 from ixdiagnose.utils.middleware import MiddlewareCommand
 
 from .base import Plugin
-from .metrics import FileMetric, MiddlewareClientMetric
+from .metrics import MiddlewareClientMetric
 from .prerequisites import VMPrerequisite
 
 
 class VM(Plugin):
     name = 'vm'
     metrics = [
-        FileMetric('haproxy', '/etc/haproxy/haproxy.cfg', extension='.cfg', prerequisites=[VMPrerequisite()]),
         MiddlewareClientMetric(
             'gpu', [MiddlewareCommand('device.get_gpus', result_key='gpus')],
             prerequisites=[VMPrerequisite()]


### PR DESCRIPTION
### Context

HAProxy was removed in DragonFish so there is no reason to capture it's contents in debug.

This PR removes the HAProxy related info gathering in VM plugin.