### PR TITLE
NAS-124248 / 23.10 / Remove password key when retrieving VM devices details (by Qubad786)

### DIFF
--- a/ixdiagnose/plugins/vm.py
+++ b/ixdiagnose/plugins/vm.py
@@ -1,3 +1,4 @@
+from ixdiagnose.utils.formatter import remove_keys
 from ixdiagnose.utils.middleware import MiddlewareCommand
 
 from .base import Plugin
@@ -21,11 +22,19 @@ class VM(Plugin):
             prerequisites=[VMPrerequisite()]
         ),
         MiddlewareClientMetric(
-            'vms', [MiddlewareCommand('vm.query', result_key='vms')],
+            'vms', [
+                MiddlewareCommand(
+                    'vm.query', result_key='vms', format_output=remove_keys(['devices.attributes.password'])
+                )
+            ],
             prerequisites=[VMPrerequisite()]
         ),
         MiddlewareClientMetric(
-            'vm_devices', [MiddlewareCommand('vm.device.query', result_key='devices')],
+            'vm_devices', [
+                MiddlewareCommand(
+                    'vm.device.query', result_key='devices', format_output=remove_keys(['attributes.password'])
+                )
+            ],
             prerequisites=[VMPrerequisite()]
         ),
     ]

--- a/ixdiagnose/test/pytest/unit/test_formatter/test_formatter.py
+++ b/ixdiagnose/test/pytest/unit/test_formatter/test_formatter.py
@@ -57,7 +57,99 @@ from ixdiagnose.utils.formatter import remove_keys
                 'domainname': 'domain2',
             },
         ],
-    )
+    ),
+    (
+        ['attributes.password'],
+        {
+            'id': 1,
+            'domainname': '',
+            'bindname': '',
+            'bindpw': '',
+            'attributes': {
+                'id': 1,
+                'password': 123
+            }
+        },
+        {
+            'id': 1,
+            'domainname': '',
+            'bindname': '',
+            'bindpw': '',
+            'attributes': {
+                'id': 1,
+            }
+        },
+    ),
+    (
+        ['devices.attributes.password'],
+        [
+          {
+            'id': 1,
+            'name': '',
+            'devices': [
+              {
+                'id': 1,
+                'attributes': {
+                  'port': 5910,
+                  'password': '1',
+                },
+              }
+            ],
+          },
+        ],
+        [
+          {
+            'id': 1,
+            'name': '',
+            'devices': [
+              {
+                'id': 1,
+                'attributes': {
+                  'port': 5910,
+                },
+              }
+            ],
+          },
+        ],
+    ),
+    (
+            ['devices.attributes.credentials.password'],
+            [
+              {
+                'id': 1,
+                'name': '',
+                'devices': [
+                  {
+                    'id': 1,
+                    'attributes': {
+                      'port': 5910,
+                      'credentials': {
+                          'name': 'test',
+                          'password': 1234
+                      },
+                    },
+                  }
+                ],
+              },
+            ],
+            [
+              {
+                'id': 1,
+                'name': '',
+                'devices': [
+                  {
+                    'id': 1,
+                    'attributes': {
+                      'port': 5910,
+                        'credentials': {
+                            'name': 'test'
+                        }
+                    },
+                  }
+                ],
+              },
+            ],
+    ),
 ])
 def test_remove_keys(keys, input_data, expected_output):
     callback = remove_keys(keys)

--- a/ixdiagnose/utils/formatter.py
+++ b/ixdiagnose/utils/formatter.py
@@ -8,15 +8,26 @@ def dumps(*args, **kwargs) -> str:
     return middleware_dumps(*args, **kwargs)
 
 
+def pop_key(output, to_find, to_remove):
+    sub_obj = get(output, to_find)
+    if isinstance(sub_obj, dict):
+        sub_obj.pop(to_remove, None)
+
+
 def remove_keys(keys: List[str]) -> Callable:
     def remove(output: Union[Dict, List]) -> Union[Dict, List]:
         if isinstance(output, dict):
             for key in keys:
                 if '.' in key:
-                    to_find, to_remove = key.rsplit('.', 1)
-                    sub_obj = get(output, to_find)
-                    if isinstance(sub_obj, dict):
-                        sub_obj.pop(to_remove, None)
+                    first_attr = get(output, key.split('.')[0])
+                    if isinstance(first_attr, list):
+                        for attr in first_attr:
+                            to_find, to_remove = key.rsplit('.', 1)
+                            to_find = to_find.split('.', 1)[1]
+                            pop_key(attr, to_find, to_remove)
+                    else:
+                        to_find, to_remove = key.rsplit('.', 1)
+                        pop_key(output, to_find, to_remove)
                 else:
                     output.pop(key, None)
         else:


### PR DESCRIPTION
### Context

This PR addresses a security concern where VM passwords are exposed in debug logs.

Applied changes remove the password key from both **vm.query** and **vm.device.query** outputs. 

Original PR: https://github.com/truenas/ixdiagnose/pull/82
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124248