### PR TITLE
NAS-124303 / 24.04 / Add glob based item to collect artifacts

### DIFF
--- a/ixdiagnose/artifacts/items/__init__.py
+++ b/ixdiagnose/artifacts/items/__init__.py
@@ -1,7 +1,8 @@
 from .base import Item
 from .directory import Directory
 from .file import File
+from .glob import Glob
 from .pattern import Pattern
 
 
-__all__ = ['Directory', 'File', 'Item', 'Pattern']
+__all__ = ['Directory', 'File', 'Glob', 'Item', 'Pattern']

--- a/ixdiagnose/artifacts/items/glob.py
+++ b/ixdiagnose/artifacts/items/glob.py
@@ -1,0 +1,90 @@
+import functools
+import os
+import glob
+import shutil
+import stat
+
+from typing import List, Optional, Tuple
+
+from .base import Item
+from .directory import copy2, get_directory_size
+
+
+class Glob(Item):
+
+    def __init__(self, name: str, max_size: Optional[int] = None, to_skip_items: Optional[list] = None):
+        super().__init__(name, max_size)
+        self.init_vars()
+        self.to_skip_items: List[str] = to_skip_items or []
+
+    def init_vars(self) -> None:
+        self.items: List[dict] = []
+
+    def initialize_context(self, item_path: str) -> None:
+        self.init_vars()
+        for entry in self.to_copy_items(item_path):
+            if os.path.isfile(entry):
+                item = {
+                    'name': os.path.basename(entry),
+                    'type': 'file',
+                    'size': os.path.getsize(entry),
+                    'path': entry,
+                }
+            else:
+                item = {
+                    'name': os.path.basename(entry),
+                    'type': 'dir',
+                    'size': get_directory_size(entry),
+                    'path': entry,
+                }
+
+            self.items.append(item)
+
+    def to_copy_items(self, items_path: str) -> list:
+        return glob.glob(items_path)
+
+    def exists(self, item_path: str) -> Tuple[bool, str]:
+        exists = bool(self.items)
+        return exists, '' if exists else f'No items found matching {self.name!r} glob pattern'
+
+    def destination_item_path(self, destination_dir: str) -> str:
+        return destination_dir
+
+    def size(self, item_path: str) -> int:
+        return sum(item['size'] for item in self.items)
+
+    def copy_validation(self, item: dict) -> Tuple[bool, str]:
+
+        if self.max_size and item['size'] > self.max_size:
+            return False, f'{item["path"]!r} exceeds specified {self.max_size!r} size'
+        elif stat.S_IRUSR & os.stat(item['path']).st_mode == 0:
+            return False, f'{item["path"]!r} is not readable'
+        return True, ''
+
+    def to_be_copied_checks(self, item_path: str) -> Tuple[bool, Optional[dict]]:
+        item_check_report = {}
+        for item in self.items:
+            to_copy, error = self.copy_validation(item)
+
+            if not to_copy:
+                item_check_report[item['path']] = error
+                self.to_skip_items.append(item['path'])
+
+        return len(self.items) != len(self.to_skip_items), item_check_report
+
+    def copy_impl(self, item_path: str, destination_path: str) -> list:
+        copied_items = []
+        for item in filter(lambda i: i['path'] not in self.to_skip_items, self.items):
+
+            destination_parent_path = os.path.join(destination_path, os.path.dirname(item['path'])[1:])
+            os.makedirs(destination_parent_path, exist_ok=True)
+            if item['type'] == 'file':
+                shutil.copy2(item['path'], destination_parent_path)
+                copied_items.append(item['path'])
+            else:
+                shutil.copytree(
+                    item['path'], os.path.join(destination_parent_path, os.path.basename(item['path'])),
+                    copy_function=functools.partial(copy2, copied_items), dirs_exist_ok=True,
+                )
+
+        return copied_items

--- a/ixdiagnose/test/pytest/integration/items/test_glob.py
+++ b/ixdiagnose/test/pytest/integration/items/test_glob.py
@@ -1,0 +1,172 @@
+import contextlib
+import os
+import tempfile
+
+from ixdiagnose.artifacts.items import Glob
+from ixdiagnose.artifacts.base import Artifact
+
+
+DATA = {
+    'files': [
+        'test_file1',
+        'test_file2',
+        'test_file3',
+    ],
+    'dirs': [
+        'test_dir1',
+        'test_dir2',
+        'test_dir3',
+    ],
+}
+DIR_TEST_FILE = 'test_dir_file'
+
+
+class TestGlob(Artifact):
+    base_dir = '/tmp'
+    name = 'test_glob'
+    items = []
+
+    def __init__(self, temp_debug_dir):
+        super().__init__()
+        self.debug_dir = temp_debug_dir
+
+    @property
+    def output_dir(self) -> str:
+        return os.path.join(self.debug_dir, self.name)
+
+
+def sort_list(list_: list):
+    list_.sort()
+    return list_
+
+
+def validate_report_data(source_path, data, report, errors=None):
+    errors = errors or {}
+    base_dict = {
+        'execution_time': 0,
+        'item_execution_error': None,
+        'item_execution_traceback': None,
+        'item_report': {
+            'traceback': None,
+            'copied_items': []
+        }
+    }
+    assert report[source_path]['execution_time'] != 0
+    base_dict['execution_time'] = report[source_path]['execution_time']
+    report[source_path]['item_report']['copied_items'].sort()
+    report_errors = report[source_path]['item_report'].pop('error')
+    base_dict['item_report']['copied_items'] = sort_list(data)
+    assert report == {source_path: base_dict}
+    if errors:
+        assert all((errors.get(k) == v for k, v in report_errors.items())) is True
+
+    return True
+
+
+@contextlib.contextmanager
+def glob_data():
+    with tempfile.TemporaryDirectory() as destination_dir:
+        with tempfile.TemporaryDirectory() as source_dir:
+            data = {'source_dir': source_dir, 'destination_dir': destination_dir, 'dirs': [], 'files': [], 'all': []}
+            for test_dir in DATA['dirs']:
+                dir_path = os.path.join(source_dir, test_dir)
+                os.mkdir(dir_path)
+                with open(os.path.join(dir_path, DIR_TEST_FILE), 'w') as f:
+                    f.write('testing  max size ' * 30)
+                data['dirs'].append(dir_path)
+                data['all'].append(os.path.join(dir_path, DIR_TEST_FILE))
+            for test_file in DATA['files']:
+                file_path = os.path.join(source_dir, test_file)
+                with open(file_path, 'w') as f:
+                    f.write('testing  max size ' * 30)
+                data['files'].append(file_path)
+                data['all'].append(file_path)
+            yield data
+
+
+def test_glob_item_artifact():
+    with glob_data() as data:
+        destination_dir = data.pop('destination_dir')
+        source_dir = f'{data.pop("source_dir")}/*'
+        TestGlob.items = [Glob(source_dir)]
+        glob_artifact = TestGlob(destination_dir)
+        glob_artifact.gather_impl()
+
+        assert sort_list(glob_artifact.debug_report[source_dir]['item_report']['copied_items']) == sort_list(
+            data['all']
+        )
+        assert all([
+            os.path.isfile(os.path.join(os.path.join(destination_dir, TestGlob.name), test_file[1:]))
+            for test_file in data['all']
+        ]) is True
+        assert validate_report_data(source_dir, data['all'], glob_artifact.debug_report) is True
+
+
+def test_glob_to_skip_items():
+    with glob_data() as data:
+        destination_dir = data.pop('destination_dir')
+        source_dir = f'{data.pop("source_dir")}/*'
+        TestGlob.items = [Glob(source_dir, to_skip_items=[data['dirs'][0], data['files'][0]])]
+        glob_artifact = TestGlob(destination_dir)
+        glob_artifact.gather_impl()
+
+        data['all'].remove(data['files'][0]), data['all'].remove(os.path.join(data['dirs'][0], DIR_TEST_FILE))
+        assert sort_list(glob_artifact.debug_report[source_dir]['item_report']['copied_items']) == sort_list(
+            data['all']
+        )
+        assert all([
+            os.path.isfile(os.path.join(os.path.join(destination_dir, TestGlob.name), test_file[1:]))
+            for test_file in data['all']
+        ]) is True
+        assert validate_report_data(source_dir, data['all'], glob_artifact.debug_report) is True
+
+
+def test_glob_item_readonly_validation():
+    with glob_data() as data:
+        destination_dir = data.pop('destination_dir')
+        source_dir = f'{data.pop("source_dir")}/*'
+        skip_dir, skip_file = data['dirs'][0], data['files'][0]
+        for skip_item in (skip_file, skip_dir):
+            os.chmod(skip_item, 0o333)
+
+        TestGlob.items = [Glob(source_dir)]
+        glob_artifact = TestGlob(destination_dir)
+        glob_artifact.gather_impl()
+
+        data['all'].remove(data['files'][0]), data['all'].remove(os.path.join(skip_dir, DIR_TEST_FILE))
+        assert sort_list(glob_artifact.debug_report[source_dir]['item_report']['copied_items']) == sort_list(
+            data['all']
+        )
+        assert all([
+            os.path.isfile(os.path.join(os.path.join(destination_dir, TestGlob.name), test_file[1:]))
+            for test_file in data['all']
+        ])
+        assert all([
+            os.path.isfile(os.path.isfile(os.path.join(os.path.join(destination_dir, TestGlob.name), skip_dir[1:]))),
+            os.path.isfile(os.path.join(os.path.join(destination_dir, TestGlob.name), skip_file[1:]))
+        ]) is False
+        assert validate_report_data(
+            source_dir, data['all'], glob_artifact.debug_report,
+            errors={file_name: f"'{file_name}' is not readable" for file_name in (skip_dir, skip_file)}
+        ) is True
+
+
+def test_glob_item_maxsize_validation():
+    with glob_data() as data:
+        destination_dir = data.pop('destination_dir')
+        source_dir = f'{data.pop("source_dir")}/*'
+        TestGlob.items = [Glob(source_dir, max_size=10)]
+        glob_artifact = TestGlob(destination_dir)
+        glob_artifact.gather_impl()
+
+        assert sort_list(glob_artifact.debug_report[source_dir]['item_report']['copied_items']) == []
+        assert not all([
+            os.path.isfile(os.path.join(os.path.join(destination_dir, TestGlob.name), test_file[1:]))
+            for test_file in data['all']
+        ])
+        assert validate_report_data(
+            source_dir, [], glob_artifact.debug_report,
+            errors={
+                file_name: f"'{file_name}' exceeds specified 10 size" for file_name in [*data['dirs'], *data['files']]
+            }
+        ) is True


### PR DESCRIPTION
## Context

It was requested that we have the feature to allow specifying a glob pattern to copy over artifacts and relevant changes have been made to introduce this functionality. To consume this functionality, following diff can be applied to make use of this:

```
diff --git a/ixdiagnose/artifacts/logs.py b/ixdiagnose/artifacts/logs.py
index b49fb2e..a55deb1 100644
--- a/ixdiagnose/artifacts/logs.py
+++ b/ixdiagnose/artifacts/logs.py
@@ -1,5 +1,5 @@
 from .base import Artifact
-from .items import Directory, File, Pattern
+from .items import Directory, File, Glob, Pattern


 class Logs(Artifact):
@@ -25,4 +25,5 @@ class Logs(Artifact):
         Pattern('fenced.+'),
         Pattern('middlewared.+'),
         Pattern('zettarepl.+'),
+        Glob('/sys/module/*/parameters/*'),
     ]
```