### PR TITLE
NAS-124597 / 23.10.1 / Collect sysfs modules parameters (by Qubad786)

### DIFF
--- a/ixdiagnose/artifacts/factory.py
+++ b/ixdiagnose/artifacts/factory.py
@@ -3,11 +3,14 @@ from ixdiagnose.utils.factory import Factory
 from .logs import Logs
 from .sys_info import SystemInfo
 from .proc import ProcFS
+from .sys_parameters import SysFSParameters
+
 
 artifact_factory = Factory()
 for artifact in [
     Logs,
-    SystemInfo,
     ProcFS,
+    SysFSParameters,
+    SystemInfo,
 ]:
     artifact_factory.register(artifact())

--- a/ixdiagnose/artifacts/sys_parameters.py
+++ b/ixdiagnose/artifacts/sys_parameters.py
@@ -1,0 +1,11 @@
+from .base import Artifact
+from .items import Glob
+
+
+class SysFSParameters(Artifact):
+    base_dir = '/sys'
+    name = 'sysfs_parameters'
+    individual_item_max_size_limit = 10 * 1024
+    items = [
+        Glob('/sys/module/*/parameters/*'),
+    ]


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 80f8969851ecde1482406f0f444b8cf055fc8278

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 16e445162d0979b7fff7c42b0fe5c283ad3756bd

## Context

It was requested that we retrieve sysfs module parameters in our debug for debugging purposes.

Original PR: https://github.com/truenas/ixdiagnose/pull/96
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124597