### PR TITLE
NAS-124585 / 23.10.1 / Make sure we set correct perms to prevent access (by Qubad786)

### DIFF
--- a/ixdiagnose/run.py
+++ b/ixdiagnose/run.py
@@ -28,7 +28,8 @@ def generate_debug() -> str:
         conf.clean_debug_path = conf.compress
         conf.debug_path = tempfile.TemporaryDirectory().name
 
-    os.makedirs(conf.debug_path, exist_ok=True)
+    os.makedirs(conf.debug_path, 0o700, exist_ok=True)
+    os.chmod(conf.debug_path, 0o700)
 
     send_event(0, 'Generating debug')
     generate_plugins_debug(total_percentage=90)
@@ -51,6 +52,8 @@ def compress_debug() -> None:
     with tarfile.open(conf.compressed_path, 'w:gz') as tar:
         for entry in os.listdir(conf.debug_path):
             tar.add(os.path.join(conf.debug_path, entry), arcname=entry)
+
+    os.chmod(conf.compressed_path, 0o700)
 
     if conf.clean_debug_path:
         shutil.rmtree(conf.debug_path, ignore_errors=True)

--- a/ixdiagnose/test/pytest/unit/run/test_debug.py
+++ b/ixdiagnose/test/pytest/unit/run/test_debug.py
@@ -73,6 +73,7 @@ def test_compression_validation(mocker, path_is_abs, debug_path, path_exists, co
 
     for method in (
         'os.makedirs',
+        'os.chmod',
         'ixdiagnose.run.generate_plugins_debug',
         'ixdiagnose.run.gather_artifacts',
         'ixdiagnose.run.compress_debug',


### PR DESCRIPTION
## Context

Whenever we create debug directory - we set it's permissions to `0o700` so other users cannot have access to the debug as it can contain sensitive information.

Original PR: https://github.com/truenas/ixdiagnose/pull/99
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124585