### PR TITLE
NAS-124706 / 23.10.1 / Save additional iSCSI configuration (by bmeagherix)

### DIFF
--- a/ixdiagnose/plugins/iscsi.py
+++ b/ixdiagnose/plugins/iscsi.py
@@ -17,7 +17,8 @@ class ISCSI(Plugin):
             MiddlewareCommand('iscsi.targetextent.query', result_key='targetextents'),
             MiddlewareCommand('iscsi.portal.query', result_key='portals'),
             MiddlewareCommand('iscsi.initiator.query', result_key='initiators'),
-            MiddlewareCommand('iscsi.auth.query', result_key='auths', format_output=remove_keys(['secret', 'peersecret'])),
+            MiddlewareCommand('iscsi.auth.query', result_key='auths',
+                              format_output=remove_keys(['secret', 'peersecret'])),
         ]),
         CommandMetric(
             'iscsi_state', [

--- a/ixdiagnose/plugins/iscsi.py
+++ b/ixdiagnose/plugins/iscsi.py
@@ -1,4 +1,5 @@
 from ixdiagnose.utils.command import Command
+from ixdiagnose.utils.formatter import remove_keys
 from ixdiagnose.utils.middleware import MiddlewareCommand
 
 from .base import Plugin
@@ -13,6 +14,10 @@ class ISCSI(Plugin):
             MiddlewareCommand('iscsi.global.config', result_key='global_config'),
             MiddlewareCommand('iscsi.target.query', result_key='targets'),
             MiddlewareCommand('iscsi.extent.query', result_key='extents'),
+            MiddlewareCommand('iscsi.targetextent.query', result_key='targetextents'),
+            MiddlewareCommand('iscsi.portal.query', result_key='portals'),
+            MiddlewareCommand('iscsi.initiator.query', result_key='initiators'),
+            MiddlewareCommand('iscsi.auth.query', result_key='auths', format_output=remove_keys(['secret', 'peersecret'])),
         ]),
         CommandMetric(
             'iscsi_state', [


### PR DESCRIPTION
When examining a Bug Report noticed that several aspects of iSCSI configuration were missing from _iscsi_conf.json_.  Add them.

Original PR: https://github.com/truenas/ixdiagnose/pull/102
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124706