### PR TITLE
NAS-125086 / 24.04 / Grab netdata logs in debug

### DIFF
--- a/ixdiagnose/artifacts/logs.py
+++ b/ixdiagnose/artifacts/logs.py
@@ -9,6 +9,7 @@ class Logs(Artifact):
     items = [
         Directory('ctdb'),
         Directory('libvirt'),
+        Directory('netdata'),
         Directory('openvpn'),
         Directory('pods'),
         Directory('proftpd'),


### PR DESCRIPTION
## Context

It is useful to have netdata logs in the debug as well so we can see why netdata might be behaving weirdly.