### PR TITLE
NAS-125087 / 23.10.1 / Add integration test for debug and compress path permissions (by Qubad786)

### DIFF
--- a/ixdiagnose/test/pytest/integration/test_compress_debug.py
+++ b/ixdiagnose/test/pytest/integration/test_compress_debug.py
@@ -50,3 +50,9 @@ def test_ixdiagnose_clean_debug(clean_debug):
             assert os.path.exists(conf.debug_path) is False
         else:
             assert os.path.exists(conf.debug_path) is True
+
+
+def test_path_perms():
+    with debug_generate(False):
+        assert (os.stat(conf.debug_path).st_mode & 0o777) == 0o700
+        assert (os.stat(conf.compressed_path).st_mode & 0o777) == 0o700


### PR DESCRIPTION
### Context

PR adds integration test to ensure that the permissions of the debug and compress paths are always set to 700.

Work was done in [this PR](https://github.com/truenas/ixdiagnose/pull/99).

Original PR: https://github.com/truenas/ixdiagnose/pull/117
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125087