### PR TITLE
NAS-125086 / 23.10.1 / Grab netdata logs in debug (by Qubad786)

### DIFF
--- a/ixdiagnose/artifacts/logs.py
+++ b/ixdiagnose/artifacts/logs.py
@@ -9,6 +9,7 @@ class Logs(Artifact):
     items = [
         Directory('ctdb'),
         Directory('libvirt'),
+        Directory('netdata'),
         Directory('openvpn'),
         Directory('pods'),
         Directory('proftpd'),


### PR DESCRIPTION
## Context

It is useful to have netdata logs in the debug as well so we can see why netdata might be behaving weirdly.

Original PR: https://github.com/truenas/ixdiagnose/pull/116
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125086