### PR TITLE
NAS-125872 / 23.10.2 / Add plugin for privilege-related info (by anodos325)

### DIFF
--- a/ixdiagnose/plugins/factory.py
+++ b/ixdiagnose/plugins/factory.py
@@ -18,6 +18,7 @@ from .kubernetes import Kubernetes
 from .ldap import LDAP
 from .network import Network
 from .nfs import NFS
+from .rbac import RBAC
 from .replication import Replication
 from .reporting import Reporting
 from .rsync import Rsync
@@ -52,6 +53,7 @@ for plugin in [
     LDAP,
     Network,
     NFS,
+    RBAC,
     Replication,
     Reporting,
     Rsync,

--- a/ixdiagnose/plugins/rbac.py
+++ b/ixdiagnose/plugins/rbac.py
@@ -1,0 +1,15 @@
+from ixdiagnose.utils.middleware import MiddlewareCommand
+
+from .base import Plugin
+from .metrics import MiddlewareClientMetric
+
+
+class RBAC(Plugin):
+    name = 'rbac'
+    metrics = [
+        MiddlewareClientMetric(
+            'privilege_information', [
+                MiddlewareCommand('privilege.query'),
+            ],
+        ),
+    ]


### PR DESCRIPTION
This commit adds new plugin to include privilege-related info in debug files.

Original PR: https://github.com/truenas/ixdiagnose/pull/136
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125872