### PR TITLE
NAS-125815 / 23.10.2 / Add enclosure2 query output to debug (by Qubad786)

### DIFF
--- a/ixdiagnose/plugins/hardware.py
+++ b/ixdiagnose/plugins/hardware.py
@@ -26,6 +26,7 @@ class Hardware(Plugin):
         FileMetric('usb_devices', '/sys/kernel/debug/usb/devices'),
         MiddlewareClientMetric('disks', [MiddlewareCommand('device.get_disks')]),
         MiddlewareClientMetric('disks_config', [MiddlewareCommand('disk.query')]),
+        MiddlewareClientMetric('enclosure2', [MiddlewareCommand('enclosure2.query')]),
         MiddlewareClientMetric('enclosures', [MiddlewareCommand('enclosure.query')]),
     ]
     raw_metrics = [


### PR DESCRIPTION
## Context

It has been requested that we include `enclosure2.query` output to our debug as it's being used in our middleware stack and can help in potentially debugging problems.

Original PR: https://github.com/truenas/ixdiagnose/pull/139
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125815