### PR TITLE
NAS-125923 / 23.10.2 / Add root password disabled override info to debug (by anodos325)

### DIFF
--- a/ixdiagnose/plugins/rbac.py
+++ b/ixdiagnose/plugins/rbac.py
@@ -10,6 +10,7 @@ class RBAC(Plugin):
         MiddlewareClientMetric(
             'privilege_information', [
                 MiddlewareCommand('privilege.query'),
+                MiddlewareCommand('privilege.always_has_root_password_enabled'),
             ],
         ),
     ]


### PR DESCRIPTION
In some cases users may disable password-based authentication for root account on NAS without providing alternative administrative account. In this situation we need to perform password validation internally in middleware (and not go through PAM). Since this impacts authentication and authorization we should flag it in the debug.

Original PR: https://github.com/truenas/ixdiagnose/pull/141
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125923