### PR TITLE
NAS-126012 / 23.10.2 / Add ability to ignore files/dirs for directory item (by Qubad786)

### DIFF
--- a/ixdiagnose/artifacts/proc.py
+++ b/ixdiagnose/artifacts/proc.py
@@ -6,4 +6,4 @@ class ProcFS(Artifact):
     base_dir = '/proc'
     name = 'proc'
     individual_item_max_size_limit = 10 * 1024 * 1024
-    items = [Directory('spl')]
+    items = [Directory(name='spl', ignore_items=['/proc/spl/kstat/zfs/dbufs'])]


### PR DESCRIPTION
### Context

Users were having large `dbufs` files which were expensive to query. 

### Change

This PR adds the functionality to skip copying files and / or directories in artifacts' directory class.
 
 Skips capturing the `/proc/spl/kstat/zfs/dbufs` file in debug to prevent unnecessary resource utilization.
 

Original PR: https://github.com/truenas/ixdiagnose/pull/148
Jira URL: https://ixsystems.atlassian.net/browse/NAS-126012