### PR TITLE
NAS-126910 / 24.10 / Grab failover config in debug

### DIFF
--- a/ixdiagnose/plugins/factory.py
+++ b/ixdiagnose/plugins/factory.py
@@ -7,6 +7,7 @@ from .cloud_sync import CloudSync
 from .containers import Containers
 from .cpu import Cpu
 from .cronjob import Cronjob
+from .failover import Failover
 from .ftp import FTP
 from .hardware import Hardware
 from .initshutdown_scripts import InitShutDownScripts
@@ -43,6 +44,7 @@ for plugin in [
     CoreGetJobs,
     Cpu,
     Cronjob,
+    Failover,
     FTP,
     Hardware,
     InitShutDownScripts,

--- a/ixdiagnose/plugins/failover.py
+++ b/ixdiagnose/plugins/failover.py
@@ -1,0 +1,15 @@
+from ixdiagnose.utils.middleware import MiddlewareCommand
+
+from .base import Plugin
+from .metrics import MiddlewareClientMetric
+
+
+class Failover(Plugin):
+    name = 'failover'
+    metrics = [
+        MiddlewareClientMetric(
+            'failover_config', [
+                MiddlewareCommand('failover.config'),
+            ]
+        ),
+    ]


### PR DESCRIPTION
### Context

This PR adds middleware command output of `failover.config` to debug's network plugin enabling visibility into network timeout settings specifically. 