### PR TITLE
NAS-126908 / 24.10 / Add /proc/net/bonding dir to debug

### DIFF
--- a/ixdiagnose/artifacts/items/directory.py
+++ b/ixdiagnose/artifacts/items/directory.py
@@ -27,7 +27,7 @@ class Directory(Item):
 
     def __init__(self, name: str, max_size: Optional[int] = None, ignore_items: Optional[List] = None):
         super().__init__(name, max_size)
-        self.ignore_items: Optional[List[str]] = ignore_items
+        self.ignore_items: List[str] = ignore_items or []
 
     def to_be_copied_checks(self, item_path: str) -> Tuple[bool, Optional[str]]:
         to_copy, error = (True, None) if os.path.isdir(item_path) else (False, f'{item_path!r} is not a directory')

--- a/ixdiagnose/artifacts/proc.py
+++ b/ixdiagnose/artifacts/proc.py
@@ -6,4 +6,7 @@ class ProcFS(Artifact):
     base_dir = '/proc'
     name = 'proc'
     individual_item_max_size_limit = 10 * 1024 * 1024
-    items = [Directory(name='spl', ignore_items=['/proc/spl/kstat/zfs/dbufs'])]
+    items = [
+        Directory('net/bonding'),
+        Directory(name='spl', ignore_items=['/proc/spl/kstat/zfs/dbufs']),
+    ]

--- a/ixdiagnose/test/pytest/integration/test_artifacts.py
+++ b/ixdiagnose/test/pytest/integration/test_artifacts.py
@@ -160,6 +160,16 @@ def test_artifact_event_progress_count():
         assert len(artifact_factory.get_items()) + 1 == len(PROGRESS_DESCRIPTIONS) == len(PROGRESS_TRACK)
 
 
+def test_directory_copy():
+    with create_items() as (source_dir, dest_dir, all_items, to_ignore):
+        directory_obj = Directory('test')
+        directory_obj.copy_impl(source_dir, dest_dir)
+
+        for item in all_items:
+            dest_item = os.path.join(dest_dir, os.path.relpath(item, source_dir))
+            assert os.path.exists(dest_item) is True
+
+
 def test_ignore_items():
     with create_items() as (source_dir, dest_dir, all_items, to_ignore):
         ignore_items = [os.path.join(source_dir, item) for item in to_ignore]


### PR DESCRIPTION
### Context

Change adds /proc/net/bonding dir in debug to give visibility for configured bonds. Also PR fixes default value handling of `ignore_items` of Directory class and adds integration test.
