### PR TITLE
NAS-126910 / 23.10.2 / Grab failover config in debug (by Qubad786)

### DIFF
--- a/ixdiagnose/plugins/factory.py
+++ b/ixdiagnose/plugins/factory.py
@@ -8,6 +8,7 @@ from .cloud_sync import CloudSync
 from .containers import Containers
 from .cpu import Cpu
 from .cronjob import Cronjob
+from .failover import Failover
 from .ftp import FTP
 from .hardware import Hardware
 from .initshutdown_scripts import InitShutDownScripts
@@ -44,6 +45,7 @@ for plugin in [
     CoreGetJobs,
     Cpu,
     Cronjob,
+    Failover,
     FTP,
     Hardware,
     InitShutDownScripts,

--- a/ixdiagnose/plugins/failover.py
+++ b/ixdiagnose/plugins/failover.py
@@ -1,0 +1,15 @@
+from ixdiagnose.utils.middleware import MiddlewareCommand
+
+from .base import Plugin
+from .metrics import MiddlewareClientMetric
+
+
+class Failover(Plugin):
+    name = 'failover'
+    metrics = [
+        MiddlewareClientMetric(
+            'failover_config', [
+                MiddlewareCommand('failover.config'),
+            ]
+        ),
+    ]


### PR DESCRIPTION
### Context

This PR adds middleware command output of `failover.config` to debug's network plugin enabling visibility into network timeout settings specifically. 

Original PR: https://github.com/truenas/ixdiagnose/pull/157
Jira URL: https://ixsystems.atlassian.net/browse/NAS-126910