### PR TITLE
NAS-126925 / 24.04-RC.1 / Do not retrieve app's history in debug (by sonicaj)

### DIFF
--- a/ixdiagnose/plugins/kubernetes.py
+++ b/ixdiagnose/plugins/kubernetes.py
@@ -1,4 +1,5 @@
 from ixdiagnose.utils.command import Command
+from ixdiagnose.utils.formatter import remove_keys
 from ixdiagnose.utils.middleware import MiddlewareCommand
 
 from .base import Plugin
@@ -31,7 +32,7 @@ class Kubernetes(Plugin):
         MiddlewareClientMetric('catalogs', [MiddlewareCommand('catalog.query')]),
         MiddlewareClientMetric(
             'chart_releases', [
-                MiddlewareCommand('chart.release.query')
+                MiddlewareCommand('chart.release.query', format_output=remove_keys(['config']))
             ], prerequisites=[ServiceRunningPrerequisite('k3s')],
         ),
     ]

--- a/ixdiagnose/plugins/kubernetes.py
+++ b/ixdiagnose/plugins/kubernetes.py
@@ -31,7 +31,7 @@ class Kubernetes(Plugin):
         MiddlewareClientMetric('catalogs', [MiddlewareCommand('catalog.query')]),
         MiddlewareClientMetric(
             'chart_releases', [
-                MiddlewareCommand('chart.release.query', [[], {'extra': {'history': True}}]),
+                MiddlewareCommand('chart.release.query')
             ], prerequisites=[ServiceRunningPrerequisite('k3s')],
         ),
     ]


### PR DESCRIPTION
This commit adds changes to not retrieve app's history in debug as it's not really useful and can be asked for later explicitly if required which would be quite rare. Secondly app's history has config of user which can contain sensitive information - it cannot be managed in the schema of app's but can be managed here, however seeing that retrieving history has little to no utility, let's remove it from debug.

Original PR: https://github.com/truenas/ixdiagnose/pull/163
Jira URL: https://ixsystems.atlassian.net/browse/NAS-126925