### PR TITLE
NAS-127353 / 24.04-RC.1 / More failover info (by yocalebo)

### DIFF
--- a/ixdiagnose/plugins/failover.py
+++ b/ixdiagnose/plugins/failover.py
@@ -2,6 +2,7 @@ from ixdiagnose.utils.middleware import MiddlewareCommand
 
 from .base import Plugin
 from .metrics import MiddlewareClientMetric
+from .prerequisites import FailoverPrerequisite
 
 
 class Failover(Plugin):
@@ -10,6 +11,25 @@ class Failover(Plugin):
         MiddlewareClientMetric(
             'failover_config', [
                 MiddlewareCommand('failover.config'),
-            ]
+            ],
+            prerequisites=[FailoverPrerequisite()],
+        ),
+        MiddlewareClientMetric(
+            'failover_event_config', [
+                MiddlewareCommand('failover.events.generate_failover_data'),
+            ],
+            prerequisites=[FailoverPrerequisite()],
+        ),
+        MiddlewareClientMetric(
+            'failover_status', [
+                MiddlewareCommand('failover.status'),
+            ],
+            prerequisites=[FailoverPrerequisite()],
+        ),
+        MiddlewareClientMetric(
+            'failover_disabled_reasons', [
+                MiddlewareCommand('failover.disabled.reasons'),
+            ],
+            prerequisites=[FailoverPrerequisite()],
         ),
     ]

--- a/ixdiagnose/plugins/prerequisites/__init__.py
+++ b/ixdiagnose/plugins/prerequisites/__init__.py
@@ -1,11 +1,12 @@
 from .active_directory import ActiveDirectoryStatePrerequisite, LDAPStatePrerequisite
 from .base import Prerequisite
+from .failover import FailoverPrerequisite
 from .service import ServiceRunningPrerequisite
 from .vm import VMPrerequisite
 
-
 __all__ = [
     'ActiveDirectoryStatePrerequisite',
+    'FailoverPrerequisite',
     'LDAPStatePrerequisite',
     'VMPrerequisite',
     'Prerequisite',

--- a/ixdiagnose/plugins/prerequisites/active_directory.py
+++ b/ixdiagnose/plugins/prerequisites/active_directory.py
@@ -10,7 +10,7 @@ class ActiveDirectoryStatePrerequisite(Prerequisite):
         return (response.output or {}).get('activedirectory') != 'DISABLED'
 
     def __str__(self):
-        return f'{self.cache_key!r} active directory service state check'
+        return 'Active directory service state check'
 
 
 class LDAPStatePrerequisite(Prerequisite):
@@ -20,4 +20,4 @@ class LDAPStatePrerequisite(Prerequisite):
         return (response.output or {}).get('ldap') != 'DISABLED'
 
     def __str__(self):
-        return f'{self.cache_key!r} ldap service state check'
+        return 'LDAP service state check'

--- a/ixdiagnose/plugins/prerequisites/failover.py
+++ b/ixdiagnose/plugins/prerequisites/failover.py
@@ -1,0 +1,12 @@
+from ixdiagnose.utils.middleware import MiddlewareCommand
+
+from .base import Prerequisite
+
+
+class FailoverPrerequisite(Prerequisite):
+
+    def evaluate_impl(self) -> bool:
+        return MiddlewareCommand('failover.licensed').execute().output
+
+    def __str__(self):
+        return f'{self.cache_key!r} failover is licensed check'

--- a/ixdiagnose/plugins/prerequisites/failover.py
+++ b/ixdiagnose/plugins/prerequisites/failover.py
@@ -9,4 +9,4 @@ class FailoverPrerequisite(Prerequisite):
         return MiddlewareCommand('failover.licensed').execute().output
 
     def __str__(self):
-        return f'{self.cache_key!r} failover is licensed check'
+        return 'Failover is licensed check'

--- a/ixdiagnose/plugins/prerequisites/vm.py
+++ b/ixdiagnose/plugins/prerequisites/vm.py
@@ -9,4 +9,4 @@ class VMPrerequisite(Prerequisite):
         return MiddlewareCommand('vm.supports_virtualization').execute().output
 
     def __str__(self):
-        return f'{self.cache_key!r} vm service state check'
+        return 'VM service state check'


### PR DESCRIPTION
Add a `FailoverPrerequisite` class and add more failover specific data to the failover plugin.

Original PR: https://github.com/truenas/ixdiagnose/pull/168
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127353