### PR TITLE
NAS-127445 / 23.10.3 / Make sure we capture samba log directories (by Qubad786)

### DIFF
--- a/ixdiagnose/artifacts/base.py
+++ b/ixdiagnose/artifacts/base.py
@@ -62,7 +62,7 @@ class Artifact:
                 item_execution_error = str(exc)
                 item_execution_traceback = traceback.format_exc()
 
-            self.debug_report[item.name] = {
+            self.debug_report[item.report_name_key] = {
                 'execution_time': time.time() - start_time,
                 'item_execution_error': item_execution_error,
                 'item_execution_traceback': item_execution_traceback,

--- a/ixdiagnose/artifacts/items/__init__.py
+++ b/ixdiagnose/artifacts/items/__init__.py
@@ -2,7 +2,7 @@ from .base import Item
 from .directory import Directory
 from .file import File
 from .glob import Glob
-from .pattern import Pattern
+from .pattern import DirectoryPattern, Pattern
 
 
-__all__ = ['Directory', 'File', 'Glob', 'Item', 'Pattern']
+__all__ = ['Directory', 'DirectoryPattern', 'File', 'Glob', 'Item', 'Pattern']

--- a/ixdiagnose/artifacts/items/base.py
+++ b/ixdiagnose/artifacts/items/base.py
@@ -16,6 +16,10 @@ class Item:
         exists = os.path.exists(item_path)
         return exists, '' if exists else f'{item_path!r} does not exist'
 
+    @property
+    def report_name_key(self):
+        return self.name
+
     def size(self, item_path: str) -> int:
         raise NotImplementedError()
 

--- a/ixdiagnose/artifacts/logs.py
+++ b/ixdiagnose/artifacts/logs.py
@@ -1,5 +1,5 @@
 from .base import Artifact
-from .items import Directory, File, Pattern
+from .items import DirectoryPattern, File, Pattern
 
 
 class Logs(Artifact):
@@ -7,14 +7,14 @@ class Logs(Artifact):
     name = 'logs'
     individual_item_max_size_limit = 10 * 1024 * 1024
     items = [
-        Directory('ctdb'),
-        Directory('jobs'),
-        Directory('libvirt'),
-        Directory('netdata'),
-        Directory('openvpn'),
-        Directory('pods'),
-        Directory('proftpd'),
-        Directory('samba4'),
+        DirectoryPattern('ctdb'),
+        DirectoryPattern('jobs'),
+        DirectoryPattern('libvirt'),
+        DirectoryPattern('netdata'),
+        DirectoryPattern('openvpn'),
+        DirectoryPattern('pods'),
+        DirectoryPattern('proftpd'),
+        DirectoryPattern('samba4'),
         File('auth.log'),
         File('debug'),
         File('dpkg.log'),

--- a/ixdiagnose/test/pytest/integration/items/test_directory_pattern.py
+++ b/ixdiagnose/test/pytest/integration/items/test_directory_pattern.py
@@ -1,0 +1,59 @@
+import contextlib
+import os
+import tempfile
+
+from ixdiagnose.artifacts.base import Artifact
+from ixdiagnose.artifacts.items import DirectoryPattern
+
+
+class TestDirectoryPattern(Artifact):
+    name = 'test_dir_pattern'
+    individual_item_max_size_limit = 1024
+
+    def __init__(self, temp_debug_dir):
+        super().__init__()
+        self.debug_dir = temp_debug_dir
+
+    @property
+    def output_dir(self) -> str:
+        return self.debug_dir
+
+
+def create_file_having_size(file_path: str, file_size: int):
+    with open(file_path, 'wb') as f:
+        f.write(os.urandom(file_size))
+
+
+@contextlib.contextmanager
+def create_items():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        source_dir = os.path.join(tmp_dir, 'source')
+        dest_dir = os.path.join(tmp_dir, 'dest')
+        os.makedirs(source_dir)
+        all_items = []
+
+        for test_dir in ['dir1', 'dir2']:
+            dir_path = os.path.join(source_dir, test_dir)
+            os.mkdir(dir_path)
+            all_items.append(dir_path)
+
+            file_path = os.path.join(dir_path, 'file')
+            with open(file_path, 'w'):
+                pass
+            all_items.append(file_path)
+
+        yield source_dir, dest_dir, all_items
+
+
+def test_directory_pattern_size_check():
+    with create_items() as (source_dir, dest_dir, all_items):
+        create_file_having_size(os.path.join(source_dir, 'dir2/file'), 2048)
+        dest_items = [item.replace(source_dir, dest_dir) for item in all_items]
+
+        TestDirectoryPattern.base_dir = source_dir
+        TestDirectoryPattern.items = [DirectoryPattern('dir1'), DirectoryPattern('dir2')]
+        artifact = TestDirectoryPattern(dest_dir)
+        artifact.gather_impl()
+
+        for item in [i for i in dest_items]:
+            assert os.path.exists(item) is True

--- a/ixdiagnose/test/pytest/integration/test_artifacts.py
+++ b/ixdiagnose/test/pytest/integration/test_artifacts.py
@@ -133,7 +133,7 @@ def test_report_schema():
                 artifact_report = json.loads(f.read())
 
             artifact = artifacts[os.path.basename(artifact_dir)]
-            assert {item.name for item in artifact.items} == set(artifact_report)
+            assert {item.report_name_key for item in artifact.items} == set(artifact_report)
 
             for item_report in artifact_report.values():
                 validate(item_report, ARTIFACT_REPORT_SCHEMA)


### PR DESCRIPTION
### Context
We had Directory type items in artifacts for which size check from `individual_item_max_size_limit` was applied to whole of directory instead of each file / subfolder of dir. That was because the above variable is not configurable at `item` level but rather `artifact` level where it sets the limit for each item in the artifact where a directory type would be 1 item.

So whenever there was a case when any subfolder crosses the size limit, the whole of dir was skipped like in case of `samba4` dir.

### Solution
Added DirectoryPattern as a new item type with the default pattern `.*` which copies complete directory just like Directory item type but applies size check on subfolders and files of the dir like Pattern item type and additionally filters can be applied as well if we want to be selective about the contents we want to retrieve from that particular directory using the glob pattern in `DirectoryPattern`.

Original PR: https://github.com/truenas/ixdiagnose/pull/170
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127445