### PR TITLE
NAS-127150 / 24.10 / Cover up usages of truecommand.connected endpoint

### DIFF
--- a/ixdiagnose/plugins/system.py
+++ b/ixdiagnose/plugins/system.py
@@ -74,7 +74,7 @@ class System(Plugin):
         MiddlewareClientMetric('system_info', [
             MiddlewareCommand('system.is_enterprise', result_key='Enterprise System'),
             MiddlewareCommand(
-                'truecommand.connected', result_key='Truecommand Status',
+                'truecommand.info', result_key='Truecommand Status',
                 format_output=remove_keys(['truecommand_ip', 'truecommand_url'])
             ),
             MiddlewareCommand('system.license', result_key='System License'),


### PR DESCRIPTION
This endpoint has been renamed in middleware and it's usages need to be covered.