### PR TITLE
NAS-127340 / 24.10 / Move scst logs into /var/log/scst.log

### DIFF
--- a/ixdiagnose/artifacts/logs.py
+++ b/ixdiagnose/artifacts/logs.py
@@ -21,6 +21,8 @@ class Logs(Artifact):
         File('error'),
         File('kern.log'),
         File('messages'),
+        File('scst.log'),
+        File('scst.log.1'),
         File('syslog'),
         File('wsdd.log'),
         Pattern('daemon.+'),


### PR DESCRIPTION
Corresponding middlewared PR #[13395 ](https://github.com/truenas/middleware/pull/13395) has been merged.