### PR TITLE
NAS-123519 / 24.10 / Add system global ID to debug

### DIFF
--- a/ixdiagnose/plugins/system.py
+++ b/ixdiagnose/plugins/system.py
@@ -71,6 +71,9 @@ class System(Plugin):
         MiddlewareClientMetric('alerts_sources_stats', [MiddlewareCommand('alert.sources_stats')]),
         MiddlewareClientMetric('middleware_tasks', [MiddlewareCommand('core.get_tasks')]),
         MiddlewareClientMetric('middleware_thread_stacks', [MiddlewareCommand('core.threads_stacks')]),
+        MiddlewareClientMetric(
+            'system_global_id', [MiddlewareCommand('system.global.id', result_key='System Global ID')],
+        ),
         MiddlewareClientMetric('system_info', [
             MiddlewareCommand('system.is_enterprise', result_key='Enterprise System'),
             MiddlewareCommand(


### PR DESCRIPTION
### Context

Change adds the system global ID to system info in system plugin. The change will help in uniquely identifying the systems.