### PR TITLE
NAS-128134 / 24.10 / Get chart release stats in debug

### DIFF
--- a/ixdiagnose/plugins/kubernetes.py
+++ b/ixdiagnose/plugins/kubernetes.py
@@ -32,7 +32,11 @@ class Kubernetes(Plugin):
         MiddlewareClientMetric('catalogs', [MiddlewareCommand('catalog.query')]),
         MiddlewareClientMetric(
             'chart_releases', [
-                MiddlewareCommand('chart.release.query', format_output=remove_keys(['config']))
+                MiddlewareCommand(
+                    'chart.release.query',
+                    [[], {'extra': {'stats': True}}],
+                    format_output=remove_keys(['config'])
+                )
             ], prerequisites=[ServiceRunningPrerequisite('k3s')],
         ),
     ]


### PR DESCRIPTION
## Context

PR adds the change to retrieve memory, network, etc stats in `chart.release.query` improving visibility