### PR TITLE
NAS-128135 / 24.04.0 / Add UPS plugin (by Qubad786)

### DIFF
--- a/ixdiagnose/plugins/factory.py
+++ b/ixdiagnose/plugins/factory.py
@@ -30,6 +30,7 @@ from .sysctl import Sysctl
 from .system import System
 from .system_state import SystemState
 from .two_factor_auth import TwoFactorAuth
+from .ups import UPS
 from .vm import VM
 from .zfs import ZFS
 
@@ -66,6 +67,7 @@ for plugin in [
     System,
     SystemState,
     TwoFactorAuth,
+    UPS,
     VM,
     ZFS,
 ]:

--- a/ixdiagnose/plugins/ups.py
+++ b/ixdiagnose/plugins/ups.py
@@ -1,0 +1,36 @@
+from typing import Any
+
+from ixdiagnose.utils.formatter import remove_keys
+from ixdiagnose.utils.middleware import MiddlewareClient, MiddlewareCommand
+from ixdiagnose.utils.run import run
+
+from .base import Plugin
+from .metrics import MiddlewareClientMetric, PythonMetric
+from .prerequisites import ServiceRunningPrerequisite
+
+
+def upsc_output(client: MiddlewareClient, context: Any) -> str:
+    ups_identifier = client.call('ups.config')['complete_identifier']
+    upsc = run(['upsc', ups_identifier], check=False)
+    if upsc.returncode:
+        return f'Failed to retrieve upsc output: {upsc.stderr}'
+    else:
+        return upsc.stdout
+
+
+class UPS(Plugin):
+    name = 'ups'
+    metrics = [
+        MiddlewareClientMetric(
+            'ups_config',
+            [
+                MiddlewareCommand('ups.config', format_output=remove_keys(['monpwd'])),
+            ]
+        ),
+        PythonMetric(
+            'upsc_output',
+            upsc_output,
+            prerequisites=[ServiceRunningPrerequisite('nut-monitor')],
+            serializable=False
+        ),
+    ]


### PR DESCRIPTION
### Context

PR adds a new plugin to include output of upsc command to debug files if ups service is running for better visibility of what's going on in their UPS parameters.

Original PR: https://github.com/truenas/ixdiagnose/pull/180
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128135