### PR TITLE
NAS-128223 / 24.04.0 / add /data/update.failed (by yocalebo)

### DIFF
--- a/ixdiagnose/plugins/system_state.py
+++ b/ixdiagnose/plugins/system_state.py
@@ -63,6 +63,7 @@ class SystemState(Plugin):
         for ds in get_ds_list()
     ] + [
         FileMetric('root_dataset_configuration', '/conf/truenas_root_ds.json', extension='.json'),
+        FileMetric('alembic_migration_errors', '/data/update.failed', extension='.failed'),
         MiddlewareClientMetric('bootenvs', [MiddlewareCommand('bootenv.query')]),
         PythonMetric('developer_mode', get_root_ds),
     ]


### PR DESCRIPTION
This file is of critical importance since it will store the error message that is received during an alembic migration during upgrades.

Original PR: https://github.com/truenas/ixdiagnose/pull/183
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128223