### PR TITLE
NAS-127517 / 24.10 / Make sure we capture k8s_api.log in the debug

### DIFF
--- a/ixdiagnose/artifacts/logs.py
+++ b/ixdiagnose/artifacts/logs.py
@@ -20,6 +20,7 @@ class Logs(Artifact):
         File('dpkg.log'),
         File('error'),
         File('kern.log'),
+        File('k8s_api.log'),
         File('messages'),
         File('scst.log'),
         File('scst.log.1'),


### PR DESCRIPTION
This commit adds changes to ensure we capture k8s api log file as well so if there were any issues on that end, we do capture them in the debug to help diagnose.