### PR TITLE
NAS-127111 / 24.10 / Grab netdata api log in debug

### DIFF
--- a/ixdiagnose/artifacts/logs.py
+++ b/ixdiagnose/artifacts/logs.py
@@ -22,6 +22,7 @@ class Logs(Artifact):
         File('kern.log'),
         File('k8s_api.log'),
         File('messages'),
+        File('netdata_api.log'),
         File('scst.log'),
         File('scst.log.1'),
         File('syslog'),


### PR DESCRIPTION
## Context

We are logging netdata client errors to a separate file and this new log file should be grabbed in the debug as well to properly help diagnose.