### PR TITLE
NAS-127111 / 24.04.1 / Grab netdata api log in debug (by Qubad786)

### DIFF
--- a/ixdiagnose/artifacts/logs.py
+++ b/ixdiagnose/artifacts/logs.py
@@ -21,6 +21,7 @@ class Logs(Artifact):
         File('error'),
         File('kern.log'),
         File('messages'),
+        File('netdata_api.log'),
         File('syslog'),
         File('wsdd.log'),
         Pattern('daemon.+'),


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x c519b7fb7db10a801af2768b4f4487417a18fb7b

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 1d43120bdec35cbe24793a87ea3fab63074f4d62

## Context

We are logging netdata client errors to a separate file and this new log file should be grabbed in the debug as well to properly help diagnose.

Original PR: https://github.com/truenas/ixdiagnose/pull/188
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127111