### PR TITLE
NAS-128631 / 24.10 / Remove extra netdata files being retrieved

### DIFF
--- a/ixdiagnose/artifacts/base.py
+++ b/ixdiagnose/artifacts/base.py
@@ -25,7 +25,7 @@ class Artifact:
 
         if self.individual_item_max_size_limit is not None:
             for item in self.items:
-                item.max_size = self.individual_item_max_size_limit
+                item.max_size = item.max_size or self.individual_item_max_size_limit
 
     @property
     def output_dir(self) -> str:

--- a/ixdiagnose/artifacts/logs.py
+++ b/ixdiagnose/artifacts/logs.py
@@ -14,7 +14,6 @@ class Logs(Artifact):
             'netdata', pattern=r'^(access|error|debug|health)\.log$', max_size=2 * 1024 * 1024,
         ),
         DirectoryPattern('openvpn'),
-        DirectoryPattern('pods'),
         DirectoryPattern('proftpd'),
         DirectoryPattern('samba4'),
         File('auth.log'),

--- a/ixdiagnose/artifacts/logs.py
+++ b/ixdiagnose/artifacts/logs.py
@@ -10,7 +10,9 @@ class Logs(Artifact):
         DirectoryPattern('ctdb'),
         DirectoryPattern('jobs'),
         DirectoryPattern('libvirt'),
-        DirectoryPattern('netdata'),
+        DirectoryPattern(
+            'netdata', pattern=r'^(access|error|debug|health)\.log$', max_size=2 * 1024 * 1024,
+        ),
         DirectoryPattern('openvpn'),
         DirectoryPattern('pods'),
         DirectoryPattern('proftpd'),


### PR DESCRIPTION
## Problem

`ixdiagnose` was copying large unnecessary compressed files from the netdata logs directory, resulting in excessively large debug size.

## Solution

Make sure we only retrieve latest files we are actually interested in wrt netdata as we can always exclusively ask for rest of them if need be in that case.
