### PR TITLE
Fix file handling for patterns

### DIFF
--- a/ixdiagnose/artifacts/items/pattern.py
+++ b/ixdiagnose/artifacts/items/pattern.py
@@ -36,7 +36,6 @@ class Pattern(Item):
             else:
                 item = File(entry.name, max_size=self.max_size, truncate=self.truncate_files)
 
-            item.initialize_context(entry.path)
             self.items.append(item)
 
     def exists(self, item_path: str) -> Tuple[bool, str]:


### PR DESCRIPTION
When we're generating item lists for patterns we shouldn't initialize and insert into list (since this leads to excessive FD consumption).