### PR TITLE
NAS-130454 / 24.10 / Add audit details to debug

### DIFF
--- a/ixdiagnose/plugins/audit.py
+++ b/ixdiagnose/plugins/audit.py
@@ -18,7 +18,14 @@ class Audit(Plugin):
                     'services': ['MIDDLEWARE'],
                     'query-filters': [['event', '=', 'METHOD_CALL']],
                     'query-options': {
-                        'select': ['audit_id', 'message_timestamp', 'username', 'event_data', 'success'],
+                        'select': [
+                            'audit_id',
+                            'message_timestamp',
+                            'service_data.origin',
+                            'service_data.credentials',
+                            'event_data',
+                            'success'
+                        ],
                         'order_by': ['-message_timestamp']
                     }
                 }]),

--- a/ixdiagnose/plugins/audit.py
+++ b/ixdiagnose/plugins/audit.py
@@ -18,7 +18,6 @@ class Audit(Plugin):
                     'services': ['MIDDLEWARE'],
                     'query-filters': [['event', '=', 'METHOD_CALL']],
                     'query-options': {
-                        'limit': 100,
                         'select': ['audit_id', 'message_timestamp', 'username', 'event_data', 'success'],
                         'order_by': ['-message_timestamp']
                     }

--- a/ixdiagnose/plugins/audit.py
+++ b/ixdiagnose/plugins/audit.py
@@ -14,7 +14,7 @@ class Audit(Plugin):
         ),
         MiddlewareClientMetric(
             'recent_audited_method_calls', [
-                MiddlewareCommand('audit.query', {
+                MiddlewareCommand('audit.query', [{
                     'services': ['MIDDLEWARE'],
                     'query-filters': [['event', '=', 'METHOD_CALL']],
                     'query-options': {
@@ -22,7 +22,7 @@ class Audit(Plugin):
                         'select': ['audit_id', 'message_timestamp', 'username', 'event_data', 'success'],
                         'order_by': ['-message_timestamp']
                     }
-                }),
+                }]),
             ],
         ),
     ]

--- a/ixdiagnose/plugins/audit.py
+++ b/ixdiagnose/plugins/audit.py
@@ -1,0 +1,28 @@
+from ixdiagnose.utils.middleware import MiddlewareCommand
+
+from .base import Plugin
+from .metrics import MiddlewareClientMetric
+
+
+class Audit(Plugin):
+    name = 'audit'
+    metrics = [
+        MiddlewareClientMetric(
+            'audit_configuration', [
+                MiddlewareCommand('audit.config'),
+            ],
+        ),
+        MiddlewareClientMetric(
+            'recent_audited_method_calls', [
+                MiddlewareCommand('audit.query', {
+                    'services': ['MIDDLEWARE'],
+                    'query-filters': [['event', '=', 'METHOD_CALL']],
+                    'query-options': {
+                        'limit': 100,
+                        'select': ['audit_id', 'message_timestamp', 'username', 'event_data', 'success'],
+                        'order_by': ['-message_timestamp']
+                    }
+                }),
+            ],
+        ),
+    ]

--- a/ixdiagnose/plugins/factory.py
+++ b/ixdiagnose/plugins/factory.py
@@ -1,6 +1,7 @@
 from ixdiagnose.utils.factory import Factory
 
 from .active_directory import ActiveDirectory
+from .audit import Audit
 from .certificates import Certificates
 from .cloud_backup import CloudBackup
 from .cloud_sync import CloudSync
@@ -37,6 +38,7 @@ from .zfs import ZFS
 plugin_factory = Factory()
 for plugin in [
     ActiveDirectory,
+    Audit,
     Certificates,
     CloudBackup,
     CloudSync,


### PR DESCRIPTION
This commit adds the following information to the debugs we collect

1. Basic audit configuration (retention period, quota, space used, etc)

2. Audit query of recent middleware method calls. List of 100 most recent audited configuration changes on the NAS. This should help support triage changes users made that may be to blame for an issue encountered.