### PR TITLE
NAS-132055 / 24.10.1 / Fix zfs get acl unit test (by Qubad786)

### DIFF
--- a/ixdiagnose/test/pytest/unit/plugins/test_zfs.py
+++ b/ixdiagnose/test/pytest/unit/plugins/test_zfs.py
@@ -54,7 +54,7 @@ def test_zfs_getacl_impl(mocker, dataset_name, props_dict, args, return_code, st
         False
     ),
     (
-        'zfs',
+        'filesystem',
         ('zfs', 'get', 'all'),
         0,
         'input_resource_output2.txt',
@@ -78,7 +78,7 @@ def test_zfs_getacl_impl(mocker, dataset_name, props_dict, args, return_code, st
         True
     ),
     (
-        'zfs',
+        'filesystem',
         ('zfs', 'get', 'all'),
         0,
         'input_resource_output3.txt',


### PR DESCRIPTION
## Context

Fix failing zfs unit test in ixdiagnose.

Original PR: https://github.com/truenas/ixdiagnose/pull/232
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132055