### PR TITLE
NAS-132049 / 24.10.0.1 / add ixnvdimm output to debug (by yocalebo) (by bugclerk)

### DIFF
--- a/ixdiagnose/plugins/hardware.py
+++ b/ixdiagnose/plugins/hardware.py
@@ -47,7 +47,7 @@ class Hardware(Plugin):
         MiddlewareClientMetric('disks_config', [MiddlewareCommand('disk.query')]),
         MiddlewareClientMetric('enclosure2', [MiddlewareCommand('enclosure2.query')]),
         MiddlewareClientMetric('enclosures', [MiddlewareCommand('enclosure.query')]),
-        PythonMetric('nvdimm_info', nvdimm_info),
+        PythonMetric('nvdimm_info', nvdimm_info, serializable=False),
     ]
     raw_metrics = [
         CommandMetric(


### PR DESCRIPTION
Simple omission that exists in CORE debug but not in SCALE debug.

Original PR: https://github.com/truenas/ixdiagnose/pull/234
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132049

Original PR: https://github.com/truenas/ixdiagnose/pull/235
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132049