### PR TITLE
NAS-132314 / 24.10.1 / add virtualization info (by yocalebo)

### DIFF
--- a/ixdiagnose/plugins/hardware.py
+++ b/ixdiagnose/plugins/hardware.py
@@ -47,6 +47,8 @@ class Hardware(Plugin):
         MiddlewareClientMetric('disks_config', [MiddlewareCommand('disk.query')]),
         MiddlewareClientMetric('enclosure2', [MiddlewareCommand('enclosure2.query')]),
         MiddlewareClientMetric('enclosures', [MiddlewareCommand('enclosure.query')]),
+        MiddlewareClientMetric('virtualization_variant', [MiddlewareCommand('hardware.virtualization.variant')]),
+        MiddlewareClientMetric('is_virtualized', [MiddlewareCommand('hardware.virtualization.is_virtualized')]),
         PythonMetric('nvdimm_info', nvdimm_info, serializable=False),
     ]
     raw_metrics = [


### PR DESCRIPTION
Adds the virtualization information provided in https://github.com/truenas/middleware/pull/14886

Original PR: https://github.com/truenas/ixdiagnose/pull/238
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132314