### PR TITLE
NAS-132315 / 24.10.1 / fix minor cosmetic ixnvdimm output (by yocalebo)

### DIFF
--- a/ixdiagnose/plugins/hardware.py
+++ b/ixdiagnose/plugins/hardware.py
@@ -15,7 +15,7 @@ def nvdimm_info(client: MiddlewareClient, context: typing.Any) -> str:
     output = ''
     with os.scandir('/dev/') as sdir:
         for i in filter(lambda x: nmem.match(x.name), sdir):
-            output += f"{'=' * 20} {i.path} {'=' * 20}"
+            output += f"{'=' * 20} {i.path} {'=' * 20}\n"
             cp = run(f'/usr/local/sbin/ixnvdimm {i.path}', check=False)
             if cp.returncode:
                 output += f'Failed to retrieve nvdimm info: {cp.stderr}\n\n'


### PR DESCRIPTION
Noticed while working on an unrelated PR. Noticed ixnvdimm output looked like this
```
==================== /dev/nmem0 ====================Module:
vendor: ce01 device: 4e39 revision: 34
subvendor: c180 subdevice: 4331 subrevision: 01
serial: 10680000
```
With the fix in place, it looks like this
```
==================== /dev/nmem0 ====================
Module:
vendor: ce01 device: 4e39 revision: 34
subvendor: c180 subdevice: 4331 subrevision: 01
serial: 10680000

Original PR: https://github.com/truenas/ixdiagnose/pull/240
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132315