### PR TITLE
NAS-132555 / 25.04 / Include snmp in plugins diagnostic.

### DIFF
--- a/ixdiagnose/plugins/factory.py
+++ b/ixdiagnose/plugins/factory.py
@@ -26,6 +26,7 @@ from .rsync import Rsync
 from .services import Services
 from .smart import SMART
 from .smb import SMB
+from .snmp import SNMP
 from .ssl import SSL
 from .sysctl import Sysctl
 from .system import System
@@ -64,6 +65,7 @@ for plugin in [
     Services,
     SMART,
     SMB,
+    SNMP,
     SSL,
     Sysctl,
     System,

--- a/ixdiagnose/plugins/snmp.py
+++ b/ixdiagnose/plugins/snmp.py
@@ -1,0 +1,22 @@
+
+from ixdiagnose.utils.formatter import remove_keys
+from ixdiagnose.utils.middleware import MiddlewareCommand
+
+from .base import Plugin
+from .metrics import MiddlewareClientMetric, DirectoryTreeMetric, FileMetric
+
+
+class SNMP(Plugin):
+    name = 'snmp'
+    metrics = [
+        MiddlewareClientMetric(
+            'snmp_config',
+            [
+                MiddlewareCommand('snmp.config', format_output=remove_keys(['v3_password', 'v3_privpassphrase'])),
+            ]
+        ),
+        FileMetric('snmp', '/etc/snmp/snmp.conf', extension='.conf'),
+        FileMetric('snmpd', '/etc/snmp/snmpd.conf', extension='.conf'),
+        DirectoryTreeMetric('custom_snmpd', '/etc/snmp/snmpd.conf.d'),
+        DirectoryTreeMetric('mibs', '/etc/snmp-mibs-downloader'),
+    ]


### PR DESCRIPTION
SNMP is missing from the diagnostic.
This PR adds SNMP configuration and associated files to a diagnostic.