### PR TITLE
NAS-132562 / 25.04 / Update LDAP config collection for sssd

### DIFF
--- a/ixdiagnose/plugins/ldap.py
+++ b/ixdiagnose/plugins/ldap.py
@@ -21,7 +21,10 @@ class LDAP(Plugin):
         FileMetric('ldap', '/etc/openldap/ldap.conf', extension='.conf'),
         CommandMetric(
             'sssd', [
-                Command(['grep', '-iv', 'ldap_default_authtok', '/etc/sssd/sssd.conf'], 'Config file', serializable=False),
+                Command(
+                    ['grep', '-iv', 'ldap_default_authtok', '/etc/sssd/sssd.conf'],
+                    'Config file', serializable=False
+                ),
             ]
         ),
         MiddlewareClientMetric(

--- a/ixdiagnose/plugins/ldap.py
+++ b/ixdiagnose/plugins/ldap.py
@@ -20,8 +20,8 @@ class LDAP(Plugin):
         FileMetric('krb5', '/etc/krb5.conf', extension='.conf'),
         FileMetric('ldap', '/etc/openldap/ldap.conf', extension='.conf'),
         CommandMetric(
-            'nslcd', [
-                Command(['grep', '-iv', 'bindpw', '/etc/nslcd.conf'], 'Config file', serializable=False),
+            'sssd', [
+                Command(['grep', '-iv', 'ldap_default_authtok', '/etc/sssd/sssd.conf'], 'Config file', serializable=False),
             ]
         ),
         MiddlewareClientMetric(


### PR DESCRIPTION
LDAP attempts to collect configuration for nslcd, but nslcd has been replaced with sssd.
This PR removes nslcd from LDAP data collection and replaces it with sssd.
Exclude password fields.

Manual test showed password field was excluded.