### PR TITLE
NAS-132548 / 25.04 / Add NVME plugin

### DIFF
--- a/ixdiagnose/plugins/factory.py
+++ b/ixdiagnose/plugins/factory.py
@@ -19,6 +19,7 @@ from .jobs import CoreGetJobs
 from .ldap import LDAP
 from .network import Network
 from .nfs import NFS
+from .nvme import NVME
 from .rbac import RBAC
 from .replication import Replication
 from .reporting import Reporting
@@ -58,6 +59,7 @@ for plugin in [
     LDAP,
     Network,
     NFS,
+    NVME,
     RBAC,
     Replication,
     Reporting,

--- a/ixdiagnose/plugins/nvme.py
+++ b/ixdiagnose/plugins/nvme.py
@@ -19,8 +19,8 @@ def get_nvme_devs() -> list[str]:
     return nvmes
 
 
-def run_nvme_cmd(action: str, nvme: str) -> str:
-    header = f"nvme {action} {nvme!r}\n"
+def run_nvme_cmd(action: str, nvme: str, add_header: bool = True) -> str:
+    header = '' if not add_header else f'{nvme:#^30}\n'
     cp = run(["nvme", action, nvme], check=False)
     if cp.returncode:
         footer = f"FAILED: {cp.stderr}\n\n"
@@ -47,7 +47,7 @@ def get_nvme_id_ns(client: MiddlewareClient, context: Any) -> str:
 def get_nvme_smart_log(client: MiddlewareClient, context: Any) -> str:
     output = ""
     for nvme in get_nvme_devs():
-        output += run_nvme_cmd("smart-log", nvme)
+        output += run_nvme_cmd("smart-log", nvme, add_header=False)
     return output
 
 

--- a/ixdiagnose/plugins/nvme.py
+++ b/ixdiagnose/plugins/nvme.py
@@ -1,0 +1,87 @@
+import os
+import re
+from typing import Any
+
+from .base import Plugin
+from .metrics import CommandMetric, PythonMetric
+from ixdiagnose.utils.command import Command
+from ixdiagnose.utils.middleware import MiddlewareClient
+from ixdiagnose.utils.run import run
+
+NVME_RE = re.compile(r"^nvme\dn\d+$")
+
+
+def get_nvme_devs() -> list[str]:
+    nvmes = list()
+    with os.scandir("/dev/") as sdir:
+        for i in filter(lambda x: NVME_RE.match(x.name), sdir):
+            nvmes.append(i.path)
+    return nvmes
+
+
+def run_nvme_cmd(action: str, nvme: str) -> str:
+    header = f"nvme {action} {nvme!r}\n"
+    cp = run(["nvme", action, nvme], check=False)
+    if cp.returncode:
+        footer = f"FAILED: {cp.stderr}\n\n"
+    else:
+        footer = cp.stdout + "\n\n"
+
+    return header + footer
+
+
+def get_nvme_id_ctrl(client: MiddlewareClient, context: Any) -> str:
+    output = ""
+    for nvme in get_nvme_devs():
+        output += run_nvme_cmd("id-ctrl", nvme)
+    return output
+
+
+def get_nvme_id_ns(client: MiddlewareClient, context: Any) -> str:
+    output = ""
+    for nvme in get_nvme_devs():
+        output += run_nvme_cmd("id-ns", nvme)
+    return output
+
+
+def get_nvme_smart_log(client: MiddlewareClient, context: Any) -> str:
+    output = ""
+    for nvme in get_nvme_devs():
+        output += run_nvme_cmd("smart-log", nvme)
+    return output
+
+
+class NVME(Plugin):
+    name = "nvme"
+    metrics = [
+        CommandMetric(
+            "nvme_list_v",
+            [
+                Command(["nvme", "list", "-v"], "nvme list -v", serializable=False),
+            ],
+        ),
+        CommandMetric(
+            "nvme_discover",
+            [
+                Command(["nvme", "discover"], "nvme discover", serializable=False),
+            ],
+        ),
+        PythonMetric(
+            "nvme_id_ctrl",
+            callback=get_nvme_id_ctrl,
+            description="Identify Controller",
+            serializable=False,
+        ),
+        PythonMetric(
+            "nvme_id_ns",
+            callback=get_nvme_id_ns,
+            description="Identify Namespace",
+            serializable=False,
+        ),
+        PythonMetric(
+            "nvme_smart_log",
+            callback=get_nvme_smart_log,
+            description="SMART Log",
+            serializable=False,
+        ),
+    ]

--- a/ixdiagnose/plugins/smart.py
+++ b/ixdiagnose/plugins/smart.py
@@ -27,7 +27,7 @@ def smart_output(client: MiddlewareClient, context: Any) -> str:
         except Exception:
             continue
 
-        cmd = ['smartctl', '-a', f'/dev/{disk}']
+        cmd = ['smartctl', '-x', f'/dev/{disk}']
         nvme_msg = ''
         if any(('nvme' in disk, vendor.lower().strip() == 'nvme')):
             # is an nvme device

--- a/ixdiagnose/plugins/smart.py
+++ b/ixdiagnose/plugins/smart.py
@@ -54,7 +54,6 @@ def smart_output(client: MiddlewareClient, context: Any) -> str:
             output += f'  {msg}\n'
             output += f'{"=" * (len(msg) + 5)}\n\n{cp.stderr if cp.returncode else cp.stdout}\n\n'
 
-    # TODO: Check the awk script and see what it normalizes
     return output
 
 


### PR DESCRIPTION
We have a severe lack of nvme information being captured in the debug. This remedies that problem based on input from platform team. This also stops calling `smartctl -a` since the command barfs a line in the output stating it's "legacy" and we should use `-x` instead.