### PR TITLE
NAS-132940 / 25.04 / fix zvol output when there are no zvols

### DIFF
--- a/ixdiagnose/plugins/zfs.py
+++ b/ixdiagnose/plugins/zfs.py
@@ -43,6 +43,10 @@ def resource_output(client: MiddlewareClient, resource_type: str) -> str:
     output = ''
     prop_dict = {}
     output_lines = cp.stdout.splitlines()
+    if not output_lines:
+        # happens when no zvols, for example
+        return output
+
     props_header = output_lines[0]
     for index, resource_line in enumerate(filter(bool, map(str.strip, output_lines[1:]))):
         resource_name = resource_line.split()[0].strip()


### PR DESCRIPTION
If there are zvols, stderr is printed to and there will be no stdout. We'll crash on `output_lines[0]` with IndexError. Just handle the fact when there is no output.