### PR TITLE
NAS-133548 / 24.10.2 / Remove modified files whitelist in `/usr` (by themylogin)

### DIFF
--- a/ixdiagnose/plugins/metrics/command.py
+++ b/ixdiagnose/plugins/metrics/command.py
@@ -42,7 +42,6 @@ class CommandMetric(Metric):
         cmd_context = []
         metric_report = []
         for cmd in self.cmds:
-            cmd.execution_context = self.execution_context
             start_time = time.time()
             cp = cmd.execute()
             report = {

--- a/ixdiagnose/plugins/system_state.py
+++ b/ixdiagnose/plugins/system_state.py
@@ -1,7 +1,5 @@
 import contextlib
-import fnmatch
 import json
-import os
 
 from ixdiagnose.utils.command import Command
 from ixdiagnose.utils.middleware import MiddlewareCommand
@@ -53,102 +51,6 @@ def get_root_ds(client: None, resource_type: str) -> dict:
     return report
 
 
-def usr_postprocess(lines: str) -> str:
-    result = []
-    for line in lines.splitlines():
-        try:
-            filename = line.split(maxsplit=1)[1].strip()
-        except IndexError:
-            pass
-        else:
-            if can_be_modified(filename):
-                continue
-
-        result.append(line)
-
-    return "\n".join(result)
-
-
-def can_be_modified(filename: str) -> bool:
-    patterns = (
-        # Modified by `middlewared.utils.rootfs.ReadonlyRootfsManager`
-        "/usr/bin/apt",
-        "/usr/bin/apt-config",
-        "/usr/bin/apt-key",
-        "/usr/bin/dpkg",
-        "/usr/local/bin/apt",
-        "/usr/local/bin/apt-config",
-        "/usr/local/bin/apt-key",
-        "/usr/local/bin/dpkg",
-        # nvidia drivers and its dependencies
-        "/usr/bin/cpp*",
-        "/usr/bin/mesa-overlay-control.py",
-        "/usr/bin/nvidia-*",
-        "/usr/bin/x86_64-linux-gnu-cpp*",
-        "/usr/include/*",
-        "/usr/lib64/xorg/modules/*",
-        "/usr/lib/cpp",
-        "/usr/lib/firmware/nvidia/*",
-        "/usr/lib/gcc/*",
-        "/usr/lib/libGL*",
-        "/usr/lib/modules/*",
-        "/usr/lib/modules/*/kernel/drivers/video",
-        "/usr/lib/modules/*/kernel/drivers/video/nvidia*",
-        "/usr/lib/modules/*/modules.*",
-        "/usr/lib/nvidia/*",
-        "/usr/lib/systemd/system/nvidia-*",
-        "/usr/lib/systemd/system-sleep/nvidia",
-        "/usr/lib/x86_64-linux-gnu/gbm/*",
-        "/usr/lib/x86_64-linux-gnu/libcuda*",
-        "/usr/lib/x86_64-linux-gnu/libEGL*",
-        "/usr/lib/x86_64-linux-gnu/libGL*",
-        "/usr/lib/x86_64-linux-gnu/libisl*",
-        "/usr/lib/x86_64-linux-gnu/libLLVM*",
-        "/usr/lib/x86_64-linux-gnu/libmpc*",
-        "/usr/lib/x86_64-linux-gnu/libnvcuvid*",
-        "/usr/lib/x86_64-linux-gnu/libnvidia*",
-        "/usr/lib/x86_64-linux-gnu/libnvoptix*",
-        "/usr/lib/x86_64-linux-gnu/libOpenCL*",
-        "/usr/lib/x86_64-linux-gnu/libOpenGL*",
-        "/usr/lib/x86_64-linux-gnu/libvdpau*",
-        "/usr/lib/x86_64-linux-gnu/libVkLayer*",
-        "/usr/lib/x86_64-linux-gnu/libvulkan*",
-        "/usr/lib/x86_64-linux-gnu/libwayland*",
-        "/usr/lib/x86_64-linux-gnu/libX11*",
-        "/usr/lib/x86_64-linux-gnu/libxcb*",
-        "/usr/lib/x86_64-linux-gnu/libxshmfence.so*",
-        "/usr/lib/x86_64-linux-gnu/pkgconfig",
-        "/usr/lib/x86_64-linux-gnu/vdpau/*",
-        "/usr/share/applications/nvidia-settings.desktop",
-        "/usr/share/bug/mesa-vulkan-drivers/*",
-        "/usr/share/doc/*",
-        "/usr/share/drirc.d/*",
-        "/usr/share/egl/*",
-        "/usr/share/gdb/*",
-        "/usr/share/glvnd/*",
-        "/usr/share/icons/hicolor/*",
-        "/usr/share/keyrings/*",
-        "/usr/share/lintian/overrides/*",
-        "/usr/share/locale/*",
-        "/usr/share/man/man*",
-        "/usr/share/nvidia/*",
-        "/usr/share/pkgconfig",
-        "/usr/share/vulkan/*",
-        "/usr/src/nvidia-*",
-    )
-    return any(should_exclude(filename, pattern) for pattern in patterns)
-
-
-def should_exclude(filename: str, pattern: str) -> bool:
-    if fnmatch.fnmatch(filename, pattern):
-        return True
-
-    if os.path.commonprefix((f"{filename}/", pattern)) == f"{filename}/":
-        return True
-
-    return False
-
-
 class SystemState(Plugin):
     name = 'system_state'
     metrics = [
@@ -156,7 +58,6 @@ class SystemState(Plugin):
             Command(
                 ['zfs', 'diff', f'{ds}@pristine'],
                 f'changes of {ds} dataset', serializable=False,
-                postprocess=usr_postprocess if ds.split('/')[-1] == 'usr' else None
             )],
         )
         for ds in get_ds_list()

--- a/ixdiagnose/utils/command.py
+++ b/ixdiagnose/utils/command.py
@@ -1,5 +1,5 @@
-from collections.abc import Callable
 import subprocess
+
 from typing import Optional, Union
 
 from .run import run
@@ -10,21 +10,16 @@ class Command:
     def __init__(
         self, command: Union[str, list], description: str, serializable: bool = True,
         safe_returncodes: list = None, env: Optional[dict] = None, max_lines: Optional[int] = None,
-        postprocess: Optional[Callable[[str], str]] = None,
     ):
         self.command: Union[str, list] = command
         self.description: str = description
         self.env: Optional[dict] = env
-        self.max_lines: Optional[int] = max_lines
+        self.max_length: Optional[int] = max_lines
         self.serializable: bool = serializable
         self.safe_returncodes: list = safe_returncodes or [0]
-        self.postprocess = postprocess
 
     def execute(self) -> subprocess.CompletedProcess:
         cp = run(self.command, check=False, env=self.env)
-        if cp.returncode in self.safe_returncodes:
-            if self.postprocess:
-                cp.stdout = self.postprocess(cp.stdout)
-            if self.max_lines:
-                cp.stdout = "\n".join(cp.stdout.splitlines()[:self.max_lines])
+        if self.max_length and cp.returncode in self.safe_returncodes:
+            cp.stdout = cp.stdout.splitlines()[:self.max_length]
         return cp

--- a/ixdiagnose/utils/command.py
+++ b/ixdiagnose/utils/command.py
@@ -1,6 +1,5 @@
 import subprocess
-
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 from .run import run
 
@@ -14,12 +13,14 @@ class Command:
         self.command: Union[str, list] = command
         self.description: str = description
         self.env: Optional[dict] = env
-        self.max_length: Optional[int] = max_lines
+        self.max_lines: Optional[int] = max_lines
         self.serializable: bool = serializable
         self.safe_returncodes: list = safe_returncodes or [0]
+        self.execution_context: Any = None
 
     def execute(self) -> subprocess.CompletedProcess:
         cp = run(self.command, check=False, env=self.env)
-        if self.max_length and cp.returncode in self.safe_returncodes:
-            cp.stdout = cp.stdout.splitlines()[:self.max_length]
+        if cp.returncode in self.safe_returncodes:
+            if self.max_lines:
+                cp.stdout = "\n".join(cp.stdout.splitlines()[:self.max_lines])
         return cp

--- a/ixdiagnose/utils/command.py
+++ b/ixdiagnose/utils/command.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable
 import subprocess
-from typing import Any, Optional, Union
+from typing import Optional, Union
 
 from .run import run
 
@@ -10,7 +10,7 @@ class Command:
     def __init__(
         self, command: Union[str, list], description: str, serializable: bool = True,
         safe_returncodes: list = None, env: Optional[dict] = None, max_lines: Optional[int] = None,
-        postprocess: Optional[Callable[[Any, str], str]] = None,
+        postprocess: Optional[Callable[[str], str]] = None,
     ):
         self.command: Union[str, list] = command
         self.description: str = description
@@ -19,13 +19,12 @@ class Command:
         self.serializable: bool = serializable
         self.safe_returncodes: list = safe_returncodes or [0]
         self.postprocess = postprocess
-        self.execution_context: Any = None
 
     def execute(self) -> subprocess.CompletedProcess:
         cp = run(self.command, check=False, env=self.env)
         if cp.returncode in self.safe_returncodes:
             if self.postprocess:
-                cp.stdout = self.postprocess(self.execution_context, cp.stdout)
+                cp.stdout = self.postprocess(cp.stdout)
             if self.max_lines:
                 cp.stdout = "\n".join(cp.stdout.splitlines()[:self.max_lines])
         return cp


### PR DESCRIPTION
Due to using `systemd-sysext`, we never modify files in `/usr` anymore.

Original PR: https://github.com/truenas/ixdiagnose/pull/255
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133548