### PR TITLE
NAS-133969 / 25.10 / Include audit SYSTEM events

### DIFF
--- a/ixdiagnose/cli.py
+++ b/ixdiagnose/cli.py
@@ -5,7 +5,7 @@ from ixdiagnose.event import event_callbacks
 from typing import Callable, List, Optional
 
 from .artifact import gather_artifacts
-from .config import conf
+from .config import conf, TIMEOUT_DEFAULT
 from .plugin import generate_plugins_debug
 from .run import generate_debug
 
@@ -87,7 +87,7 @@ def validate_path(ctx, param, value):
 
 
 timeout_option = click.option(
-    '-t', '--timeout', type=click.INT, default=20, show_default=True,
+    '-t', '--timeout', type=click.INT, default=TIMEOUT_DEFAULT, show_default=True,
     help='timeout value for middleware client in seconds'
 )
 

--- a/ixdiagnose/config.py
+++ b/ixdiagnose/config.py
@@ -1,6 +1,8 @@
 from jsonschema import validate
 from typing import List, Optional
 
+TIMEOUT_DEFAULT = 30
+
 
 class Configuration:
 
@@ -26,7 +28,7 @@ class Configuration:
         self.exclude_artifacts: List[str] = []
         self.exclude_plugins: List[str] = []
         self.structured_data: bool = False
-        self.timeout: int = 20
+        self.timeout: int = TIMEOUT_DEFAULT
 
     def apply(self, new_config: dict) -> None:
         validate(new_config, self.SCHEMA)

--- a/ixdiagnose/plugins/audit.py
+++ b/ixdiagnose/plugins/audit.py
@@ -46,7 +46,7 @@ class Audit(Plugin):
                     ['aureport'], 'auditd summary report', serializable=False
                 ),
                 Command(
-                    ['ausearch --format csv -m ALL --start week-ago --end now | head -101'],
+                    ['ausearch --format csv -m ALL --start week-ago --end now | head -101 | grep -v TTY'],
                     'Recent auditd enties (csv format)', serializable=False
                 ),
             ],

--- a/ixdiagnose/plugins/audit.py
+++ b/ixdiagnose/plugins/audit.py
@@ -32,9 +32,27 @@ class Audit(Plugin):
                 }]),
             ],
         ),
+        MiddlewareClientMetric(
+            'recent_audited_system_calls', [
+                MiddlewareCommand('audit.query', [{
+                    'services': ['SYSTEM'],
+                    # No filter, collect all
+                    'query-options': {
+                        'select': [
+                            'audit_id',
+                            'message_timestamp',
+                            'event_data',
+                            'success'
+                        ],
+                        'order_by': ['-message_timestamp'],
+                        'limit': 100
+                    }
+                }]),
+            ],
+        ),
         CommandMetric(
             # This generates a file that is collected in the associated FileMetric.
-            'truenas_verify_data', [
+            'audit_data', [
                 Command(
                     ['truenas_verify'], 'Result from truenas_verify', serializable=False,
                     safe_returncodes=[],  # With no safe_returncodes we can silently run the command
@@ -44,10 +62,6 @@ class Audit(Plugin):
                 ),
                 Command(
                     ['aureport'], 'auditd summary report', serializable=False
-                ),
-                Command(
-                    ['ausearch --format csv -m ALL --start week-ago --end now | head -101 | grep -v TTY'],
-                    'Recent auditd enties (csv format)', serializable=False
                 ),
             ],
         ),

--- a/ixdiagnose/plugins/audit.py
+++ b/ixdiagnose/plugins/audit.py
@@ -36,11 +36,18 @@ class Audit(Plugin):
             # This generates a file that is collected in the associated FileMetric.
             'truenas_verify_data', [
                 Command(
+                    ['truenas_verify'], 'Result from truenas_verify', serializable=False,
+                    safe_returncodes=[],  # With no safe_returncodes we can silently run the command
+                ),
+                Command(
                     ['shasum', '-a', '256', '/conf/rootfs.mtree'], 'sha256 rootfs.mtree', serializable=False
                 ),
                 Command(
-                    ['truenas_verify'], 'Result from truenas_verify', serializable=False,
-                    safe_returncodes=[],  # With no safe_returncodes we can silently run the command
+                    ['aureport'], 'auditd summary report', serializable=False
+                ),
+                Command(
+                    ['ausearch --format csv -m ALL --start week-ago --end now | head -101'],
+                    'Recent auditd enties (csv format)', serializable=False
                 ),
             ],
         ),


### PR DESCRIPTION
This PR adds the 100 most recent SYSTEM event audit entries, a sha256 sum of `/conf/rootfs.mtree` and an `aureport`.
All will be contained in `plugins/audit`.

Also,
Changed default timeout from 20 to 30 seconds.
The addition of verify can take longer than 20 seconds on VMs with few cores or weak machines.