### PR TITLE
NAS-134761 / 25.04.0 / Redact virt instance output (by anodos325)

### DIFF
--- a/ixdiagnose/plugins/virt.py
+++ b/ixdiagnose/plugins/virt.py
@@ -1,4 +1,5 @@
 from ixdiagnose.utils.command import Command
+from ixdiagnose.utils.formatter import remove_keys
 from ixdiagnose.utils.middleware import MiddlewareCommand
 
 from .base import Plugin
@@ -13,7 +14,9 @@ class Virt(Plugin):
         ]),
         MiddlewareClientMetric('virt_global_config', [MiddlewareCommand('virt.global.config')]),
         MiddlewareClientMetric(
-            'virt_instances', [MiddlewareCommand('virt.instance.query', [[], {'extra': {'raw': True}}])]
+            'virt_instances', [
+                MiddlewareCommand('virt.instance.query', format_output=remove_keys(['vnc_password']))
+            ]
         ),
         MiddlewareClientMetric('virt_volumes', [MiddlewareCommand('virt.volume.query')]),
         CommandMetric('incus_commands', [


### PR DESCRIPTION
This commit removes raw keys from the virt instance output in debugs since it may leak sensitive information.

Original PR: https://github.com/truenas/ixdiagnose/pull/271
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134761