### PR TITLE
NAS-134820 / 25.10 / Filter out SERVICE_START and SERVICE_STOP audit messages

### DIFF
--- a/ixdiagnose/plugins/audit.py
+++ b/ixdiagnose/plugins/audit.py
@@ -36,10 +36,10 @@ class Audit(Plugin):
             'recent_audited_system_calls', [
                 MiddlewareCommand('audit.query', [{
                     'services': ['SYSTEM'],
-                    'query-filters': {[
+                    'query-filters': [
                         ["event_data.service_action", "!=", "SERVICE_START"],
                         ["event_data.service_action", "!=", "SERVICE_STOP"]
-                    ]},
+                    ],
                     'query-options': {
                         'select': [
                             'audit_id',

--- a/ixdiagnose/plugins/audit.py
+++ b/ixdiagnose/plugins/audit.py
@@ -36,7 +36,10 @@ class Audit(Plugin):
             'recent_audited_system_calls', [
                 MiddlewareCommand('audit.query', [{
                     'services': ['SYSTEM'],
-                    # No filter, collect all
+                    'query-filters': {[
+                        ["event_data.service_action", "!=", "SERVICE_START"],
+                        ["event_data.service_action", "!=", "SERVICE_STOP"]
+                    ]},
                     'query-options': {
                         'select': [
                             'audit_id',


### PR DESCRIPTION
We collect the 100 most recent `SYSTEM` audit messages.    The large number of `SERVICE_START` and `SERVICE_STOP` messages easily fills the 100 message allocation.  This results in missing potentially important and interesting `SYSTEM` messages.

This PR adds a filter to the collection of `SYSTEM` audit messages to ignore `SERVICE_START` and `SERVICE_STOP` messages.

This PR has companion PR in `middleware` and `audit_rules`.