### PR TITLE
NAS-135138 / 25.10 / Add Fibre Channel information

### DIFF
--- a/ixdiagnose/plugins/factory.py
+++ b/ixdiagnose/plugins/factory.py
@@ -11,6 +11,7 @@ from .cpu import Cpu
 from .cronjob import Cronjob
 from .exceptions import LoggedExceptions
 from .failover import Failover
+from .fc import FibreChannel
 from .ftp import FTP
 from .hardware import Hardware
 from .initshutdown_scripts import InitShutDownScripts
@@ -54,6 +55,7 @@ for plugin in [
     Cpu,
     Cronjob,
     Failover,
+    FibreChannel,
     FTP,
     Hardware,
     InitShutDownScripts,

--- a/ixdiagnose/plugins/fc.py
+++ b/ixdiagnose/plugins/fc.py
@@ -1,0 +1,29 @@
+from ixdiagnose.utils.middleware import MiddlewareCommand
+
+from .base import Plugin
+from .metrics import MiddlewareClientMetric
+from .prerequisites import FibreChannelPrerequisite
+
+
+class FibreChannel(Plugin):
+    name = 'fc'
+    metrics = [
+        MiddlewareClientMetric(
+            'fc_hosts', [
+                MiddlewareCommand('fc.fc_hosts'),
+            ],
+            prerequisites=[FibreChannelPrerequisite()],
+        ),
+        MiddlewareClientMetric(
+            'fc_host_pairs', [
+                MiddlewareCommand('fc.fc_host.query'),
+            ],
+            prerequisites=[FibreChannelPrerequisite()],
+        ),
+        MiddlewareClientMetric(
+            'fcport', [
+                MiddlewareCommand('fcport.query'),
+            ],
+            prerequisites=[FibreChannelPrerequisite()],
+        ),
+    ]

--- a/ixdiagnose/plugins/prerequisites/__init__.py
+++ b/ixdiagnose/plugins/prerequisites/__init__.py
@@ -1,12 +1,14 @@
 from .active_directory import ActiveDirectoryStatePrerequisite, LDAPStatePrerequisite
 from .base import Prerequisite
 from .failover import FailoverPrerequisite
+from .fc import FibreChannelPrerequisite
 from .service import ServiceRunningPrerequisite
 from .vm import VMPrerequisite
 
 __all__ = [
     'ActiveDirectoryStatePrerequisite',
     'FailoverPrerequisite',
+    'FibreChannelPrerequisite',
     'LDAPStatePrerequisite',
     'VMPrerequisite',
     'Prerequisite',

--- a/ixdiagnose/plugins/prerequisites/fc.py
+++ b/ixdiagnose/plugins/prerequisites/fc.py
@@ -1,0 +1,12 @@
+from ixdiagnose.utils.middleware import MiddlewareCommand
+
+from .base import Prerequisite
+
+
+class FibreChannelPrerequisite(Prerequisite):
+
+    def evaluate_impl(self) -> bool:
+        return MiddlewareCommand('fc.capable').execute().output
+
+    def __str__(self):
+        return 'Fibre Channel is licensed and available check'


### PR DESCRIPTION
Add Fibre Channel information to debug.

While _scst.conf_ will contain information about configured FC targets, it may be useful to have more **raw** data to debug any issues that arise.