### PR TITLE
NAS-135625 / 25.10 / Add nvmet information to debug

### DIFF
--- a/ixdiagnose/plugins/factory.py
+++ b/ixdiagnose/plugins/factory.py
@@ -22,6 +22,7 @@ from .ldap import LDAP
 from .network import Network
 from .nfs import NFS
 from .nvme import NVME
+from .nvmet import NVMet
 from .rbac import RBAC
 from .replication import Replication
 from .reporting import Reporting
@@ -66,6 +67,7 @@ for plugin in [
     Network,
     NFS,
     NVME,
+    NVMet,
     RBAC,
     Replication,
     Reporting,

--- a/ixdiagnose/plugins/nvmet.py
+++ b/ixdiagnose/plugins/nvmet.py
@@ -1,0 +1,23 @@
+from ixdiagnose.utils.formatter import redact_keys
+from ixdiagnose.utils.middleware import MiddlewareCommand
+
+from .base import Plugin
+from .metrics import MiddlewareClientMetric
+
+
+class NVMet(Plugin):
+    name = 'nvmet'
+    metrics = [
+        MiddlewareClientMetric('nvmet_config', [
+            MiddlewareCommand('nvmet.global.config', result_key='global_config'),
+            MiddlewareCommand('nvmet.host.query', result_key='hosts',
+                              format_output=redact_keys(['dhchap_key', 'dhchap_ctrl_key'])),
+            MiddlewareCommand('nvmet.host_subsys.query', result_key='host_subsys',
+                              format_output=redact_keys(['host.nvmet_host_dhchap_key',
+                                                         'host.nvmet_host_dhchap_ctrl_key'])),
+            MiddlewareCommand('nvmet.namespace.query', result_key='namespaces'),
+            MiddlewareCommand('nvmet.port.query', result_key='ports'),
+            MiddlewareCommand('nvmet.port_subsys.query', result_key='port_subsys'),
+            MiddlewareCommand('nvmet.subsys.query', result_key='subsys'),
+        ]),
+    ]

--- a/ixdiagnose/utils/formatter.py
+++ b/ixdiagnose/utils/formatter.py
@@ -37,3 +37,39 @@ def remove_keys(keys: List[str]) -> Callable:
 
         return output
     return remove
+
+
+def redact_str(value):
+    if isinstance(value, str):
+        return '*' * len(value)
+    return value
+
+
+def redact_key(output, to_find, to_remove):
+    sub_obj = get(output, to_find)
+    if isinstance(sub_obj, dict):
+        sub_obj[to_remove] = redact_str(sub_obj[to_remove])
+
+
+def redact_keys(keys: List[str]) -> Callable:
+    def redact(output: Union[Dict, List]) -> Union[Dict, List]:
+        if isinstance(output, dict):
+            for key in keys:
+                if '.' in key:
+                    first_attr = get(output, key.split('.')[0])
+                    if isinstance(first_attr, list):
+                        for attr in first_attr:
+                            to_find, to_remove = key.rsplit('.', 1)
+                            to_find = to_find.split('.', 1)[1]
+                            redact_key(attr, to_find, to_remove)
+                    else:
+                        to_find, to_remove = key.rsplit('.', 1)
+                        redact_key(output, to_find, to_remove)
+                else:
+                    output[key] = redact_str(output[key])
+        else:
+            for item in output:
+                redact(item)
+
+        return output
+    return redact


### PR DESCRIPTION
- Add nvmet information to debug
- Add `redact_keys` formatter, modelled on `remove_keys`

The latter is for when we want to keep information private, but still show that a setting was set (or not).