### PR TITLE
NAS-135636 / 25.04.2 / Add system security config to debug (by anodos325)

### DIFF
--- a/ixdiagnose/plugins/system.py
+++ b/ixdiagnose/plugins/system.py
@@ -84,4 +84,5 @@ class System(Plugin):
             MiddlewareCommand('system.info', result_key='system_info'),
         ]),
         MiddlewareClientMetric('system_dataset', [MiddlewareCommand('systemdataset.config')]),
+        MiddlewareClientMetric('system_security', [MiddlewareCommand('system.security.config')]),
     ]


### PR DESCRIPTION
This catches STIG, FIPS, and account policy settings

Original PR: https://github.com/truenas/ixdiagnose/pull/280
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135636