### PR TITLE
NAS-135769 / 25.10 / Add sssd logs to artifacts.

### DIFF
--- a/ixdiagnose/artifacts/logs.py
+++ b/ixdiagnose/artifacts/logs.py
@@ -15,6 +15,7 @@ class Logs(Artifact):
         DirectoryPattern('openvpn'),
         DirectoryPattern('proftpd'),
         DirectoryPattern('samba4'),
+        DirectoryPattern('sssd', pattern=r'^(ldap_child|sssd)_?(.*)?(\.log)(\.1)?$'),
         File('app_lifecycle.log'),
         File('app_migrations.log'),
         File('auth.log'),


### PR DESCRIPTION
### Add sssd logs to collection of artifacts.

```
root@fangtooth-hv-rc[~]# ls /var/log/sssd
ldap_child.log  sssd.log.2.gz  sssd_mcgipa.mcg.log       sssd_mcgipa.mcg.log.3.gz  sssd_nss.log.1     sssd_nss.log.4.gz  sssd_pac.log.2.gz  sssd_pam.log.1
sssd.log        sssd.log.3.gz  sssd_mcgipa.mcg.log.1     sssd_mcgipa.mcg.log.4.gz  sssd_nss.log.2.gz  sssd_pac.log       sssd_pac.log.3.gz  sssd_pam.log.2.gz
sssd.log.1      sssd.log.4.gz  sssd_mcgipa.mcg.log.2.gz  sssd_nss.log              sssd_nss.log.3.gz  sssd_pac.log.1     sssd_pam.log       sssd_pam.log.3.gz
root@fangtooth-hv-rc[~]#
root@fangtooth-hv-rc[~]#
root@fangtooth-hv-rc[~]# ixdiagnose artifact --debug-path=/root
Specified configuration for debug generation is
- timeout for debug generation: 30 seconds.
- debug path set to /root
Completed debug  [####################################]  100%
Collected artifacts at /root
root@fangtooth-hv-rc[~]# ls ixdiagnose/artifacts/logs/sssd
ldap_child.log  sssd.log  sssd.log.1  sssd_mcgipa.mcg.log  sssd_mcgipa.mcg.log.1  sssd_nss.log  sssd_nss.log.1  sssd_pac.log  sssd_pac.log.1  sssd_pam.log  sssd_pam.log.1
```