### PR TITLE
Add new SSH plugin to debugs

### DIFF
--- a/ixdiagnose/plugins/factory.py
+++ b/ixdiagnose/plugins/factory.py
@@ -31,6 +31,7 @@ from .services import Services
 from .smart import SMART
 from .smb import SMB
 from .snmp import SNMP
+from .ssh import SSH
 from .ssl import SSL
 from .sysctl import Sysctl
 from .system import System
@@ -76,6 +77,7 @@ for plugin in [
     SMART,
     SMB,
     SNMP,
+    SSH,
     SSL,
     Sysctl,
     System,

--- a/ixdiagnose/plugins/metrics/base.py
+++ b/ixdiagnose/plugins/metrics/base.py
@@ -6,10 +6,10 @@ from typing import Any, List, Tuple
 
 class Metric:
 
-    def __init__(self, name: str, prerequisites: List[Prerequisite] = None):
+    def __init__(self, name: str, prerequisites: List[Prerequisite] | None = None):
         self.execution_context: Any = None
-        self.name: str = name
-        self.prerequisites: List[Prerequisite] = prerequisites or []
+        self.name = name
+        self.prerequisites = prerequisites or []
 
         assert type(name) is str and bool(name) is True
         assert type(self.prerequisites) is list

--- a/ixdiagnose/plugins/metrics/file.py
+++ b/ixdiagnose/plugins/metrics/file.py
@@ -8,7 +8,13 @@ from .base import Metric
 
 class FileMetric(Metric):
 
-    def __init__(self, name: str, file_path: str, prerequisites: List[Prerequisite] = None, extension: str = '.txt'):
+    def __init__(self, name: str, file_path: str, prerequisites: List[Prerequisite] | None = None, extension: str = '.txt'):
+        """
+        :param name: Name of the output file (not including the file extension).
+        :param file_path: Path of the file to copy into the debug.
+        :param prerequisites: List of `Prerequisite`s that must all evaluate to true before executing this `Metric`.
+        :param extension: File extension to use for the output file.
+        """
         super().__init__(name, prerequisites)
         self.extension: str = extension
         self.file_path: str = file_path

--- a/ixdiagnose/plugins/ssh.py
+++ b/ixdiagnose/plugins/ssh.py
@@ -1,4 +1,3 @@
-
 from ixdiagnose.utils.formatter import redact_keys
 from ixdiagnose.utils.middleware import MiddlewareCommand
 

--- a/ixdiagnose/plugins/ssh.py
+++ b/ixdiagnose/plugins/ssh.py
@@ -1,0 +1,23 @@
+
+from ixdiagnose.utils.formatter import redact_keys
+from ixdiagnose.utils.middleware import MiddlewareCommand
+
+from .base import Plugin
+from .metrics import MiddlewareClientMetric, FileMetric
+
+
+class SSH(Plugin):
+    name = 'ssh'
+    metrics = [
+        MiddlewareClientMetric(
+            'ssh_config',
+            [MiddlewareCommand(
+                'ssh.config',
+                format_output=redact_keys([
+                    'privatekey', 'host_dsa_key', 'host_ecdsa_key', 'host_ed25519_key', 'host_key', 'host_rsa_key'
+                ])
+            )]
+        ),
+        FileMetric('sshd', '/etc/pam.d/sshd'),
+        FileMetric('sshd_config', '/etc/ssh/sshd_config'),
+    ]

--- a/ixdiagnose/utils/formatter.py
+++ b/ixdiagnose/utils/formatter.py
@@ -48,7 +48,7 @@ def remove_keys(keys: Iterable[str]) -> Callable[[_T], _T]:
 
 def redact_str(value):
     if isinstance(value, str):
-        # Replace with an arbitrary number of asterisks.
+        # Replace with an arbitrary number of asterisks to conceal length.
         return '*' * 8
     return value
 

--- a/ixdiagnose/utils/middleware.py
+++ b/ixdiagnose/utils/middleware.py
@@ -3,7 +3,7 @@ import contextlib
 from dataclasses import dataclass
 from ixdiagnose.config import conf
 from truenas_api_client import Client
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, Optional
 
 
 MiddlewareClient: Client = Client
@@ -25,14 +25,21 @@ class MiddlewareResponse:
 
 class MiddlewareCommand:
     def __init__(
-        self, endpoint: str, api_payload: Optional[List] = None, format_output: Optional[Callable] = None,
+        self, endpoint: str, api_payload: Optional[list] = None, format_output: Optional[Callable[[Any], Any]] = None,
         result_key: Optional[str] = None, job: bool = False,
     ):
-        self.endpoint: str = endpoint
-        self.overridden_format_output: Optional[Callable] = format_output
-        self.payload: List = api_payload or []
-        self.result_key: str = result_key or self.endpoint.replace('.', '_')
-        self.job: bool = job
+        """
+        :param endpoint: The API method to call.
+        :param api_payload: Arguments to pass to `endpoint`.
+        :param format_output: Optional function that takes the API method's result and returns it in a new form.
+        :param result_key: Defaults to `endpoint` with periods replaced with underscores.
+        :param job: `endpoint` is a job.
+        """
+        self.endpoint = endpoint
+        self.overridden_format_output = format_output
+        self.payload = api_payload or []
+        self.result_key = result_key or self.endpoint.replace('.', '_')
+        self.job = job
 
     def format_output(self, output: Any) -> Any:
         return self.overridden_format_output(output) if self.overridden_format_output else output


### PR DESCRIPTION
The new plugin will have three metrics:
* output of `ssh.config` API method call with keys redacted
* copy of `/etc/pam.d/sshd`
* copy of `/etc/ssh/sshd_config`

I have changed the redaction string to be 8 consecutive asterisks (*) regardless of the length of the string being redacted.

All other changes are docstring/type hint improvements.