### PR TITLE
NAS-136068 / 25.04.2 / Add new SSH plugin to debugs (by creatorcary)

### DIFF
--- a/ixdiagnose/plugins/factory.py
+++ b/ixdiagnose/plugins/factory.py
@@ -30,6 +30,7 @@ from .services import Services
 from .smart import SMART
 from .smb import SMB
 from .snmp import SNMP
+from .ssh import SSH
 from .ssl import SSL
 from .sysctl import Sysctl
 from .system import System
@@ -74,6 +75,7 @@ for plugin in [
     SMART,
     SMB,
     SNMP,
+    SSH,
     SSL,
     Sysctl,
     System,

--- a/ixdiagnose/plugins/metrics/base.py
+++ b/ixdiagnose/plugins/metrics/base.py
@@ -8,8 +8,8 @@ class Metric:
 
     def __init__(self, name: str, prerequisites: List[Prerequisite] | None = None):
         self.execution_context: Any = None
-        self.name: str = name
-        self.prerequisites: List[Prerequisite] = prerequisites or []
+        self.name = name
+        self.prerequisites = prerequisites or []
 
         assert type(name) is str and bool(name) is True
         assert type(self.prerequisites) is list

--- a/ixdiagnose/plugins/metrics/file.py
+++ b/ixdiagnose/plugins/metrics/file.py
@@ -8,7 +8,15 @@ from .base import Metric
 
 class FileMetric(Metric):
 
-    def __init__(self, name: str, file_path: str, prerequisites: List[Prerequisite] = None, extension: str = '.txt'):
+    def __init__(
+        self, name: str, file_path: str, prerequisites: List[Prerequisite] | None = None, extension: str = '.txt'
+    ):
+        """
+        :param name: Name of the output file (not including the file extension).
+        :param file_path: Path of the file to copy into the debug.
+        :param prerequisites: List of `Prerequisite`s that must all evaluate to true before executing this `Metric`.
+        :param extension: File extension to use for the output file.
+        """
         super().__init__(name, prerequisites)
         self.extension: str = extension
         self.file_path: str = file_path

--- a/ixdiagnose/plugins/ssh.py
+++ b/ixdiagnose/plugins/ssh.py
@@ -1,0 +1,23 @@
+from ixdiagnose.utils.formatter import redact_keys
+from ixdiagnose.utils.middleware import MiddlewareCommand
+
+from .base import Plugin
+from .metrics import MiddlewareClientMetric, FileMetric
+
+
+class SSH(Plugin):
+    name = 'ssh'
+    metrics = [
+        MiddlewareClientMetric(
+            'ssh_config',
+            [MiddlewareCommand(
+                'ssh.config',
+                format_output=redact_keys(include=[
+                    'id', 'bindiface', 'tcpport', 'password_login_groups', 'passwordauth', 'kerberosauth', 'tcpfwd',
+                    'compression', 'sftp_log_level', 'sftp_log_facility', 'weak_ciphers', 'options',
+                ])
+            )]
+        ),
+        FileMetric('sshd', '/etc/pam.d/sshd'),
+        FileMetric('sshd_config', '/etc/ssh/sshd_config'),
+    ]

--- a/ixdiagnose/test/pytest/unit/test_formatter/test_formatter.py
+++ b/ixdiagnose/test/pytest/unit/test_formatter/test_formatter.py
@@ -1,156 +1,202 @@
 import pytest
 
-from ixdiagnose.utils.formatter import remove_keys
+from ixdiagnose.utils.formatter import remove_keys, redact_keys, REDACTED
 
 
-@pytest.mark.parametrize('keys,input_data,expected_output', [
-    (
-        ['bindpw'],
-        {
-            'id': 1,
-            'domainname': '',
-            'bindname': '',
-            'bindpw': '',
-        },
-        {
-            'id': 1,
-            'domainname': '',
-            'bindname': '',
-        },
-    ),
-    (
-        ['bindpw', 'bindname'],
-        {
-            'id': 1,
-            'domainname': '',
-            'bindname': '',
-            'bindpw': '',
-        },
-        {
-            'id': 1,
-            'domainname': '',
-        },
-    ),
-    (
-        ['bindpw', 'bindname'],
-        [
+def formatter_input():
+    return {
+        'a': {'f1': 1, 'f2': {'f3': 3, 'f4': 4}},
+        'b': {'f1': 1, 'f2': {'f3': 3, 'f4': 4}},
+        'c': {'f1': 1, 'f2': {'f3': 3, 'f4': 4}},
+        'd': {'f1': 1, 'f2': {'f3': 3, 'f4': 4}},
+    }
+
+
+@pytest.mark.parametrize(
+    'keys,input_data,expected_output',
+    [
+        (
+            ['bindpw'],
             {
                 'id': 1,
-                'domainname': 'domain1',
+                'domainname': '',
                 'bindname': '',
                 'bindpw': '',
             },
             {
-                'id': 2,
-                'domainname': 'domain2',
+                'id': 1,
+                'domainname': '',
+                'bindname': '',
+            },
+        ),
+        (
+            ['bindpw', 'bindname'],
+            {
+                'id': 1,
+                'domainname': '',
                 'bindname': '',
                 'bindpw': '',
             },
-        ],
-        [
             {
                 'id': 1,
-                'domainname': 'domain1',
+                'domainname': '',
             },
-            {
-                'id': 2,
-                'domainname': 'domain2',
-            },
-        ],
-    ),
-    (
-        ['attributes.password'],
-        {
-            'id': 1,
-            'domainname': '',
-            'bindname': '',
-            'bindpw': '',
-            'attributes': {
-                'id': 1,
-                'password': 123
-            }
-        },
-        {
-            'id': 1,
-            'domainname': '',
-            'bindname': '',
-            'bindpw': '',
-            'attributes': {
-                'id': 1,
-            }
-        },
-    ),
-    (
-        ['devices.attributes.password'],
-        [
-          {
-            'id': 1,
-            'name': '',
-            'devices': [
-              {
-                'id': 1,
-                'attributes': {
-                  'port': 5910,
-                  'password': '1',
-                },
-              }
-            ],
-          },
-        ],
-        [
-          {
-            'id': 1,
-            'name': '',
-            'devices': [
-              {
-                'id': 1,
-                'attributes': {
-                  'port': 5910,
-                },
-              }
-            ],
-          },
-        ],
-    ),
-    (
-            ['devices.attributes.credentials.password'],
+        ),
+        (
+            ['bindpw', 'bindname'],
             [
-              {
+                {
+                    'id': 1,
+                    'domainname': 'domain1',
+                    'bindname': '',
+                    'bindpw': '',
+                },
+                {
+                    'id': 2,
+                    'domainname': 'domain2',
+                    'bindname': '',
+                    'bindpw': '',
+                },
+            ],
+            [
+                {
+                    'id': 1,
+                    'domainname': 'domain1',
+                },
+                {
+                    'id': 2,
+                    'domainname': 'domain2',
+                },
+            ],
+        ),
+        (
+            ['attributes.password'],
+            {
+                'id': 1,
+                'domainname': '',
+                'bindname': '',
+                'bindpw': '',
+                'attributes': {
+                    'id': 1,
+                    'password': 123
+                }
+            },
+            {
+                'id': 1,
+                'domainname': '',
+                'bindname': '',
+                'bindpw': '',
+                'attributes': {
+                    'id': 1,
+                }
+            },
+        ),
+        (
+            ['devices.attributes.password'],
+            [{
                 'id': 1,
                 'name': '',
-                'devices': [
-                  {
+                'devices': [{
                     'id': 1,
                     'attributes': {
-                      'port': 5910,
-                      'credentials': {
-                          'name': 'test',
-                          'password': 1234
-                      },
+                        'port': 5910,
+                        'password': '1',
                     },
-                  }
-                ],
-              },
-            ],
-            [
-              {
+                }],
+            }],
+            [{
                 'id': 1,
                 'name': '',
-                'devices': [
-                  {
+                'devices': [{
                     'id': 1,
                     'attributes': {
-                      'port': 5910,
+                        'port': 5910,
+                    },
+                }],
+            }],
+        ),
+        (
+            ['devices.attributes.credentials.password'],
+            [{
+                'id': 1,
+                'name': '',
+                'devices': [{
+                    'id': 1,
+                    'attributes': {
+                        'port': 5910,
+                        'credentials': {
+                            'name': 'test',
+                            'password': 1234
+                        },
+                    },
+                }],
+            }],
+            [{
+                'id': 1,
+                'name': '',
+                'devices': [{
+                    'id': 1,
+                    'attributes': {
+                        'port': 5910,
                         'credentials': {
                             'name': 'test'
                         }
                     },
-                  }
-                ],
-              },
-            ],
-    ),
-])
+                }],
+            }],
+        ),
+    ]
+)
 def test_remove_keys(keys, input_data, expected_output):
     callback = remove_keys(keys)
+    assert callback(input_data) == expected_output
+
+
+@pytest.mark.parametrize(
+    'params, input_data, expected_output',
+    [
+        (
+            {'include': ('a', 'b.f1', 'd.f2.f3')},
+            formatter_input(),
+            {
+                'a': {'f1': 1, 'f2': {'f3': 3, 'f4': 4}},
+                'b': {'f1': 1, 'f2': REDACTED},
+                'c': REDACTED,
+                'd': {'f1': REDACTED, 'f2': {'f3': 3, 'f4': REDACTED}},
+            },
+        ),
+        (
+            {'include': ('a', 'b.f1', 'd.f2.f3')},
+            [formatter_input()],
+            [{
+                'a': {'f1': 1, 'f2': {'f3': 3, 'f4': 4}},
+                'b': {'f1': 1, 'f2': REDACTED},
+                'c': REDACTED,
+                'd': {'f1': REDACTED, 'f2': {'f3': 3, 'f4': REDACTED}},
+            }],
+        ),
+        (
+            {'exclude': ('a', 'b.f1', 'd.f2.f3')},
+            formatter_input(),
+            {
+                'a': REDACTED,
+                'b': {'f1': REDACTED, 'f2': {'f3': 3, 'f4': 4}},
+                'c': {'f1': 1, 'f2': {'f3': 3, 'f4': 4}},
+                'd': {'f1': 1, 'f2': {'f3': REDACTED, 'f4': 4}},
+            },
+        ),
+        (
+            {'exclude': ('a', 'b.f1', 'd.f2.f3')},
+            [formatter_input()],
+            [{
+                'a': REDACTED,
+                'b': {'f1': REDACTED, 'f2': {'f3': 3, 'f4': 4}},
+                'c': {'f1': 1, 'f2': {'f3': 3, 'f4': 4}},
+                'd': {'f1': 1, 'f2': {'f3': REDACTED, 'f4': 4}},
+            }],
+        ),
+    ]
+)
+def test_redact_keys(params, input_data, expected_output):
+    callback = redact_keys(**params)
     assert callback(input_data) == expected_output

--- a/ixdiagnose/utils/middleware.py
+++ b/ixdiagnose/utils/middleware.py
@@ -1,9 +1,9 @@
 import contextlib
-
 from dataclasses import dataclass
-from ixdiagnose.config import conf
+from typing import Any, Callable, Optional, TypeAlias
+
 from truenas_api_client import Client
-from typing import Any, Callable, List, Optional, TypeAlias
+from ixdiagnose.config import conf
 
 
 MiddlewareClient: TypeAlias = Client
@@ -25,14 +25,21 @@ class MiddlewareResponse:
 
 class MiddlewareCommand:
     def __init__(
-        self, endpoint: str, api_payload: Optional[List] = None, format_output: Optional[Callable] = None,
+        self, endpoint: str, api_payload: Optional[list] = None, format_output: Optional[Callable[[Any], Any]] = None,
         result_key: Optional[str] = None, job: bool = False,
     ):
-        self.endpoint: str = endpoint
-        self.overridden_format_output: Optional[Callable] = format_output
-        self.payload: List = api_payload or []
-        self.result_key: str = result_key or self.endpoint.replace('.', '_')
-        self.job: bool = job
+        """
+        :param endpoint: The API method to call.
+        :param api_payload: Arguments to pass to `endpoint`.
+        :param format_output: Optional function that takes the API method's result and returns it in a new form.
+        :param result_key: Defaults to `endpoint` with periods replaced with underscores.
+        :param job: `endpoint` is a job.
+        """
+        self.endpoint = endpoint
+        self.overridden_format_output = format_output
+        self.payload = api_payload or []
+        self.result_key = result_key or self.endpoint.replace('.', '_')
+        self.job = job
 
     def format_output(self, output: Any) -> Any:
         return self.overridden_format_output(output) if self.overridden_format_output else output


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 3e1d701caa4d3658c7e3383c0af8cbc2c50509df
    git cherry-pick -x 852b6560d5c323fec47fad828dfabfbeda7e84a6
    git cherry-pick -x c3be6392a1deb841cfa9f6af6cb55754be875396
    git cherry-pick -x c180bf963ede8408d304e4d361c789fe82224347
    git cherry-pick -x 606513e2ff16dbe6cf0ab4597d3f85d8ba8ad013
    git cherry-pick -x 4a9e5cbb37ee227a93516f8cd3f61f7a8bbc0391
    git cherry-pick -x a2d312d1b86b3e9d6234db05089b9e6a03ba0302
    git cherry-pick -x 2443d8b6dee5652ae34e6a5154c430572a4bb34d
    git cherry-pick -x 8b172d37c9808f3e837cae8f82757b85d46a391a

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 4a44bb9f22b469c79bb96fcfcedf0e020d8690ab

The new plugin will have three metrics:
* output of `ssh.config` API method call with keys redacted
* copy of `/etc/pam.d/sshd`
* copy of `/etc/ssh/sshd_config`

I have changed the redaction string to be 8 consecutive asterisks (*) regardless of the length of the string being redacted.

I have also improved the redaction formatter so that it may now accept either a whitelist or blacklist of keys.

All other changes are docstring/type hint improvements.

Original PR: https://github.com/truenas/ixdiagnose/pull/292
Jira URL: https://ixsystems.atlassian.net/browse/NAS-136068