### PR TITLE
NAS-135912 / 25.10 / Add fcdump.py output to debug

### DIFF
--- a/ixdiagnose/plugins/fc.py
+++ b/ixdiagnose/plugins/fc.py
@@ -1,13 +1,21 @@
 from ixdiagnose.utils.middleware import MiddlewareCommand
 
 from .base import Plugin
-from .metrics import MiddlewareClientMetric
+from .metrics import CommandMetric, MiddlewareClientMetric
+from ixdiagnose.utils.command import Command
 from .prerequisites import FibreChannelPrerequisite
 
 
 class FibreChannel(Plugin):
     name = 'fc'
     metrics = [
+        CommandMetric(
+            "fcdump",
+            [
+                Command(["fcdump.py", "--format", "text"], "fcdump.py --format text", serializable=False),
+            ],
+            prerequisites=[FibreChannelPrerequisite()],
+        ),
         MiddlewareClientMetric(
             'fc_hosts', [
                 MiddlewareCommand('fc.fc_hosts'),


### PR DESCRIPTION
Support wanted to add additional Fibre Channel output, both as a live tool on the system and also to debugs.