### PR TITLE
NAS-136919 / 24.10.2.4 / Remove core.get_tasks from debug collection (by anodos325)

### DIFF
--- a/ixdiagnose/plugins/system.py
+++ b/ixdiagnose/plugins/system.py
@@ -69,7 +69,6 @@ class System(Plugin):
         ]),
         MiddlewareClientMetric('alerts', [MiddlewareCommand('alert.list')]),
         MiddlewareClientMetric('alerts_sources_stats', [MiddlewareCommand('alert.sources_stats')]),
-        MiddlewareClientMetric('middleware_tasks', [MiddlewareCommand('core.get_tasks')]),
         MiddlewareClientMetric('middleware_thread_stacks', [MiddlewareCommand('core.threads_stacks')]),
         MiddlewareClientMetric(
             'system_global_id', [MiddlewareCommand('system.global.id', result_key='System Global ID')],


### PR DESCRIPTION
There is a possibility if the timing of tasks gathering is just right that sensitive information may leak into debugs. Since there is no practical way to redact stack info with 100% certainty we'll just accept the reduced ability to debug reported issues.

Original PR: https://github.com/truenas/ixdiagnose/pull/301
