### PR TITLE
NAS-136934 / 26.04 / Collect systemd pstore crash dumps in ixdiagnose

### DIFF
--- a/ixdiagnose/artifacts/crashdump.py
+++ b/ixdiagnose/artifacts/crashdump.py
@@ -7,5 +7,5 @@ class Crashdump(Artifact):
     name = 'crashdump'
     individual_item_max_size_limit = 1 * 1024 * 1024
     items = [
-        Glob('pstore/*/dmesg.txt'),
+        Glob('pstore/*/dmesg.txt', relative_to='/var/lib/systemd'),
     ]

--- a/ixdiagnose/artifacts/crashdump.py
+++ b/ixdiagnose/artifacts/crashdump.py
@@ -1,0 +1,11 @@
+from .base import Artifact
+from .items import Glob
+
+
+class Crashdump(Artifact):
+    base_dir = '/var/lib/systemd'
+    name = 'crashdump'
+    individual_item_max_size_limit = 1 * 1024 * 1024
+    items = [
+        Glob('pstore/*/dmesg.txt'),
+    ]

--- a/ixdiagnose/artifacts/factory.py
+++ b/ixdiagnose/artifacts/factory.py
@@ -1,18 +1,18 @@
 from ixdiagnose.utils.factory import Factory
 
+from .crashdump import Crashdump
 from .logs import Logs
 from .proc import ProcFS
 from .sys_info import SystemInfo
 from .sys_parameters import SysFSParameters
-from .crashdump import Crashdump
 
 
 artifact_factory = Factory()
 for artifact in [
+    Crashdump,
     Logs,
     ProcFS,
     SysFSParameters,
     SystemInfo,
-    Crashdump,
 ]:
     artifact_factory.register(artifact())

--- a/ixdiagnose/artifacts/factory.py
+++ b/ixdiagnose/artifacts/factory.py
@@ -4,6 +4,7 @@ from .logs import Logs
 from .proc import ProcFS
 from .sys_info import SystemInfo
 from .sys_parameters import SysFSParameters
+from .crashdump import Crashdump
 
 
 artifact_factory = Factory()
@@ -12,5 +13,6 @@ for artifact in [
     ProcFS,
     SysFSParameters,
     SystemInfo,
+    Crashdump,
 ]:
     artifact_factory.register(artifact())

--- a/ixdiagnose/artifacts/items/glob.py
+++ b/ixdiagnose/artifacts/items/glob.py
@@ -12,10 +12,14 @@ from .directory import copy2, get_directory_size
 
 class Glob(Item):
 
-    def __init__(self, name: str, max_size: Optional[int] = None, to_skip_items: Optional[list] = None):
+    def __init__(
+        self, name: str, max_size: Optional[int] = None, to_skip_items: Optional[list] = None,
+        relative_to: Optional[str] = None
+    ):
         super().__init__(name, max_size)
         self.init_vars()
         self.to_skip_items: List[str] = to_skip_items or []
+        self.relative_to: Optional[str] = relative_to
 
     def init_vars(self) -> None:
         self.items: List[dict] = []
@@ -76,7 +80,11 @@ class Glob(Item):
         copied_items = []
         for item in filter(lambda i: i['path'] not in self.to_skip_items, self.items):
 
-            destination_parent_path = os.path.join(destination_path, os.path.dirname(item['path'])[1:])
+            if self.relative_to:
+                relative_path = os.path.relpath(item['path'], self.relative_to)
+                destination_parent_path = os.path.join(destination_path, os.path.dirname(relative_path))
+            else:
+                destination_parent_path = os.path.join(destination_path, os.path.dirname(item['path'])[1:])
             os.makedirs(destination_parent_path, exist_ok=True)
             if item['type'] == 'file':
                 shutil.copy2(item['path'], destination_parent_path)


### PR DESCRIPTION
ACPI ERST is selected as the pstore backend by default, which dumps kernel dmesg buffer to ACPI ERST tables that are later concatenated by systemd. We have ACPI ERST tables available on almost all enterprise platforms, and panic dumps are already logged to `/var/lib/systemd/pstore/` by the systemd-pstore service. This change integrates the crash dumps into ixdiagnose.

### Testing
- The following is the structure of the generated crash dump.
```
$ tree artifacts/crashdump/
artifacts/crashdump/
├── pstore
│   ├── 7535166971441053699
│   │   └── dmesg.txt
│   └── 7535167727355297793
│       └── dmesg.txt
└── report.json


7 directories, 3 files
```
- Validated that the crashdump artifacts correctly updated after a panic.
- [Scale Build](http://jenkins.eng.ixsystems.net:8080/job/master/job/custom/1402/).