### PR TITLE
NAS-137047 / 26.04 / sysfs_parameters: Use relative_to for clean structure

### DIFF
--- a/ixdiagnose/artifacts/sys_parameters.py
+++ b/ixdiagnose/artifacts/sys_parameters.py
@@ -3,9 +3,9 @@ from .items import Glob
 
 
 class SysFSParameters(Artifact):
-    base_dir = '/sys'
+    base_dir = '/sys/module'
     name = 'sysfs_parameters'
     individual_item_max_size_limit = 10 * 1024
     items = [
-        Glob('/sys/module/*/parameters/*'),
+        Glob('*/parameters/*', relative_to='/sys/module'),
     ]


### PR DESCRIPTION
Use the relative_to parameter introduced in PR #305 to create cleaner directory structure. `sysfs_parameters/sys/module/*/parameters/*` becomes `sysfs_parameters/*/parameters/*`.