### PR TITLE
NAS-137236 / 25.10-RC.1 / Grab additional metrics from docker in debug (by sonicaj)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,6 +5,7 @@ Maintainer: Muhammad Rehan <mrehan@ixsystems.com>
 Build-Depends: debhelper-compat (= 12),
                dh-python,
                python3-dev,
+               python3-docker,
                python3-jsonschema,
                python3-setuptools
 Standards-Version: 4.4.1
@@ -13,7 +14,8 @@ Testsuite: autopkgtest-pkg-python
 
 Package: python3-ixdiagnose
 Architecture: any
-Depends: python3-jsonschema,
+Depends: python3-docker,
+         python3-jsonschema,
          smartmontools,
          ${shlibs:Depends},
          ${misc:Depends},

--- a/ixdiagnose/plugins/apps.py
+++ b/ixdiagnose/plugins/apps.py
@@ -22,20 +22,38 @@ def docker_container_inspect(middleware_client, context):
         for container in containers:
             # Get container attributes
             attrs = container.attrs
+            state = attrs.get('State', {})
+
+            health_data = state.get('Health', {})
+            if health_data:
+                health_info = {
+                    'status': health_data.get('Status', None),
+                    'failing_streak': health_data.get('FailingStreak', 0),
+                    'log_count': len(health_data.get('Log', []))
+                }
+            else:
+                health_info = None
+
             container_info = {
                 'name': container.name,
                 'id': container.short_id,
                 'full_id': container.id,
                 'status': container.status,
                 'restart_count': attrs.get('RestartCount', 0),
-                'started_at': attrs.get('State', {}).get('StartedAt', ''),
-                'finished_at': attrs.get('State', {}).get('FinishedAt', ''),
-                'exit_code': attrs.get('State', {}).get('ExitCode', ''),
-                'oom_killed': attrs.get('State', {}).get('OOMKilled', False),
-                'pid': attrs.get('State', {}).get('Pid', ''),
+                'started_at': state.get('StartedAt', ''),
+                'finished_at': state.get('FinishedAt', ''),
+                'exit_code': state.get('ExitCode', ''),
+                'oom_killed': state.get('OOMKilled', False),
+                'pid': state.get('Pid', ''),
+                'running': state.get('Running', False),
+                'paused': state.get('Paused', False),
+                'restarting': state.get('Restarting', False),
+                'dead': state.get('Dead', False),
+                'error': state.get('Error', ''),
                 'image': attrs.get('Config', {}).get('Image', ''),
                 'created': attrs.get('Created', ''),
                 'restart_policy': attrs.get('HostConfig', {}).get('RestartPolicy', {}),
+                'health': health_info,
             }
             containers_info.append(container_info)
 

--- a/ixdiagnose/plugins/apps.py
+++ b/ixdiagnose/plugins/apps.py
@@ -1,8 +1,52 @@
+import docker
+
 from ixdiagnose.utils.command import Command
 from ixdiagnose.utils.middleware import MiddlewareCommand
 
 from .base import Plugin
-from .metrics import CommandMetric, MiddlewareClientMetric
+from .metrics import CommandMetric, MiddlewareClientMetric, PythonMetric
+from .prerequisites import ServiceRunningPrerequisite
+
+
+def docker_container_inspect(middleware_client, context):
+    try:
+        client = docker.from_env()
+
+        # Get all containers (including stopped ones)
+        containers = client.containers.list(all=True)
+
+        if not containers:
+            return {'containers': [], 'error': None}
+
+        containers_info = []
+        for container in containers:
+            # Get container attributes
+            attrs = container.attrs
+            container_info = {
+                'name': container.name,
+                'id': container.short_id,
+                'full_id': container.id,
+                'status': container.status,
+                'restart_count': attrs.get('RestartCount', 0),
+                'started_at': attrs.get('State', {}).get('StartedAt', ''),
+                'finished_at': attrs.get('State', {}).get('FinishedAt', ''),
+                'exit_code': attrs.get('State', {}).get('ExitCode', ''),
+                'oom_killed': attrs.get('State', {}).get('OOMKilled', False),
+                'pid': attrs.get('State', {}).get('Pid', ''),
+                'image': attrs.get('Config', {}).get('Image', ''),
+                'created': attrs.get('Created', ''),
+                'restart_policy': attrs.get('HostConfig', {}).get('RestartPolicy', {}),
+            }
+            containers_info.append(container_info)
+
+    except Exception as e:
+        return {'containers': [], 'error': f'Unexpected error: {e}', 'total_containers': 0}
+    else:
+        return {
+            'containers': containers_info,
+            'total_containers': len(containers_info),
+            'error': None,
+        }
 
 
 class Apps(Plugin):
@@ -11,6 +55,21 @@ class Apps(Plugin):
         CommandMetric('docker_logs', [
             Command('journalctl -u docker | tail -n 1000', 'Docker logs', serializable=False),
         ]),
+        CommandMetric('docker_processes', [
+            Command(['docker', 'ps', '-a'], 'Docker processes (all containers)', serializable=False),
+        ], prerequisites=[ServiceRunningPrerequisite('docker')]),
+        CommandMetric('docker_images', [
+            Command(['docker', 'images', '-a'], 'Docker images (all)', serializable=False),
+        ], prerequisites=[ServiceRunningPrerequisite('docker')]),
+        CommandMetric('docker_networks', [
+            Command(['docker', 'network', 'ls'], 'Docker networks', serializable=False),
+        ], prerequisites=[ServiceRunningPrerequisite('docker')]),
+        CommandMetric('docker_volumes', [
+            Command(['docker', 'volume', 'ls'], 'Docker volumes', serializable=False),
+        ], prerequisites=[ServiceRunningPrerequisite('docker')]),
+        CommandMetric('docker_stats', [
+            Command(['docker', 'stats', '--no-stream'], 'Docker container resource usage', serializable=False),
+        ], prerequisites=[ServiceRunningPrerequisite('docker')]),
         MiddlewareClientMetric('app_images', [MiddlewareCommand('app.image.query')]),
         MiddlewareClientMetric('app_dockerhub_limit', [MiddlewareCommand('app.image.dockerhub_rate_limit')]),
         MiddlewareClientMetric('apps', [MiddlewareCommand('app.query')]),
@@ -20,4 +79,8 @@ class Apps(Plugin):
         MiddlewareClientMetric('catalog_trains', [MiddlewareCommand('catalog.trains')]),
         MiddlewareClientMetric('docker_config', [MiddlewareCommand('docker.config')]),
         MiddlewareClientMetric('docker_status', [MiddlewareCommand('docker.status')]),
+        PythonMetric(
+            'docker_container_inspect', docker_container_inspect, 'Docker container detailed inspection',
+            prerequisites=[ServiceRunningPrerequisite('docker')], serializable=True,
+        ),
     ]


### PR DESCRIPTION
This PR adds changes to get some more diagnostic information from docker.

(docker is already included in the build, using it here as well to have a cleaner interface to get relevant information)

Original PR: https://github.com/truenas/ixdiagnose/pull/309
