### PR TITLE
NAS-136827 / 25.10-RC.1 / Add jbof_view to hardware plugin (by bmeagherix)

### DIFF
--- a/ixdiagnose/plugins/hardware.py
+++ b/ixdiagnose/plugins/hardware.py
@@ -9,6 +9,7 @@ from ixdiagnose.utils.run import run
 
 from .base import Plugin
 from .metrics import CommandMetric, FileMetric, MiddlewareClientMetric, PythonMetric
+from .prerequisites import JBOFPrerequisite
 
 
 def nvdimm_info(client: MiddlewareClient, context: typing.Any) -> str:
@@ -32,6 +33,12 @@ class Hardware(Plugin):
             'dmidecode', [
                 Command(['dmidecode'], 'Dmidecode', serializable=False),
             ],
+        ),
+        CommandMetric(
+            "jbof_view", [
+                Command(["jbof_view.py", "--both"], "jbof_view.py --both", serializable=False),
+            ],
+            prerequisites=[JBOFPrerequisite()],
         ),
         CommandMetric(
             'pci', [

--- a/ixdiagnose/plugins/prerequisites/__init__.py
+++ b/ixdiagnose/plugins/prerequisites/__init__.py
@@ -2,6 +2,7 @@ from .directoryservices import ActiveDirectoryStatePrerequisite, DomainJoinedPre
 from .base import Prerequisite
 from .failover import FailoverPrerequisite
 from .fc import FibreChannelPrerequisite
+from .jbof import JBOFPrerequisite
 from .service import ServiceRunningPrerequisite
 from .vm import VMPrerequisite
 
@@ -10,6 +11,7 @@ __all__ = [
     'DomainJoinedPrerequisite',
     'FailoverPrerequisite',
     'FibreChannelPrerequisite',
+    'JBOFPrerequisite',
     'VMPrerequisite',
     'Prerequisite',
     'ServiceRunningPrerequisite',

--- a/ixdiagnose/plugins/prerequisites/jbof.py
+++ b/ixdiagnose/plugins/prerequisites/jbof.py
@@ -1,0 +1,12 @@
+from ixdiagnose.utils.middleware import MiddlewareCommand
+
+from .base import Prerequisite
+
+
+class JBOFPrerequisite(Prerequisite):
+
+    def evaluate_impl(self) -> bool:
+        return int(MiddlewareCommand('jbof.query', [[], {'count': True}]).execute().output) > 0
+
+    def __str__(self):
+        return 'JBOF is configured check'


### PR DESCRIPTION
Add `jbof_view` to `hardware` plugin - gated by `JBOFPrerequisite`.


WIP pending underlying jbof_view.py script being added to build (middleware PR).


Original PR: https://github.com/truenas/ixdiagnose/pull/312
