### PR TITLE
NAS-140520 / 26.0.0-BETA.1 / Use caller privilege context to determine job visibility in debug files (by Qubad786)

### DIFF
--- a/ixdiagnose/config.py
+++ b/ixdiagnose/config.py
@@ -20,6 +20,7 @@ class Configuration:
             'include_plugins': {'type': 'array', 'items': {'type': 'string'}},
             'structured_data': {'type': 'boolean'},
             'timeout': {'type': 'integer'},
+            'caller_has_full_admin': {'type': 'boolean'},
         },
     }
 
@@ -33,6 +34,7 @@ class Configuration:
         self.include_plugins: List[str] = []
         self.structured_data: bool = False
         self.timeout: int = TIMEOUT_DEFAULT
+        self.caller_has_full_admin: bool = True
 
     def apply(self, new_config: dict) -> None:
         validate(new_config, self.SCHEMA)

--- a/ixdiagnose/plugins/jobs.py
+++ b/ixdiagnose/plugins/jobs.py
@@ -1,11 +1,23 @@
-from ixdiagnose.utils.middleware import MiddlewareCommand
+from ixdiagnose.config import conf
+from ixdiagnose.utils.middleware import MiddlewareClient, get_admin_middleware_client
 
 from .base import Plugin
-from .metrics import MiddlewareClientMetric
+from .metrics import PythonMetric
+
+RAW_RESULT_PARAMS = [[], {'extra': {'raw_result': False}}]
+
+
+def get_jobs(client: MiddlewareClient, context) -> dict:
+    if conf.caller_has_full_admin:
+        with get_admin_middleware_client() as admin_client:
+            jobs = admin_client.call('core.get_jobs', *RAW_RESULT_PARAMS)
+    else:
+        jobs = client.call('core.get_jobs', *RAW_RESULT_PARAMS)
+    return {'key': 'core_get_jobs', 'output': jobs}
 
 
 class CoreGetJobs(Plugin):
     name = 'jobs'
     metrics = [
-        MiddlewareClientMetric('jobs', [MiddlewareCommand('core.get_jobs', [[], {'extra': {'raw_result': False}}])]),
+        PythonMetric('jobs', get_jobs),
     ]


### PR DESCRIPTION
## Problem

When generating a system debug, `jobs.json` contains only 2-3 jobs instead of the full set. This is because `get_middleware_client()` calls `privilege.become_readonly()` before all API calls, which drops the credential from FULL_ADMIN to READONLY_ADMIN. While this correctly triggers Secret field redaction, it also activates per-user job filtering in `core.get_jobs` — since the ixdiagnose client session owns no jobs, the result is nearly empty.

The jobs plugin was using `MiddlewareCommand` which goes through the `become_readonly()` client, subject to the same per-user filtering as any READONLY_ADMIN user on the live API.

## Solution

Add a `caller_has_full_admin` configuration flag (default `True` for CLI invocations). The middleware sets this flag based on the triggering user's actual privilege level before calling `generate_debug()`.

The jobs plugin now uses a `PythonMetric` callback that checks this flag:
- When `True`: creates its own admin client via `get_admin_middleware_client()` (bypassing `become_readonly()`) to get full job visibility
- When `False`: uses the shared readonly client with per-user filtering intact

Secret field redaction is preserved in both paths because `raw_result=False` is always passed to `core.get_jobs`, which forces `Job.__encode__()` to call `dump_result(expose_secrets=False)` unconditionally — arguments are also always redacted via `dump_args()` with `expose_secrets=False`.

Original PR: https://github.com/truenas/ixdiagnose/pull/350
