### PR TITLE
NAS-140593 / 26.0.0-BETA.2 / Use /run/middleware instead of /var/run/middleware (by Qubad786)

### DIFF
--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup dependencies
       run: |
         FAKE_ENV=1 /usr/bin/install-dev-tools
-        mkdir -p /var/run/middleware
+        mkdir -p /run/middleware
     - name: Deps
       run: |
         pip install --break-system-packages -r requirements.txt

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup dependencies
       run: |
         FAKE_ENV=1 /usr/bin/install-dev-tools
-        mkdir -p /var/run/middleware
+        mkdir -p /run/middleware
 
     - name: Deps
       run: |

--- a/ixdiagnose/config.py
+++ b/ixdiagnose/config.py
@@ -2,7 +2,7 @@ from jsonschema import validate
 from typing import List, Optional
 
 
-RUN_DIR = '/var/run/middleware'
+RUN_DIR = '/run/middleware'
 TIMEOUT_DEFAULT = 30
 
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 6d808d0b82a62532ef8831026ebde6cc78260b00

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 8f87721f0b04e9232fa0dc6a67ee7043506ea0cc



Original PR: https://github.com/truenas/ixdiagnose/pull/353
