### PR TITLE
NAS-141443 / 27.0.0-BETA.1 / Collect debug info for the container plugin

### DIFF
--- a/ixdiagnose/plugins/containers.py
+++ b/ixdiagnose/plugins/containers.py
@@ -1,9 +1,16 @@
 from json import loads
+from typing import Any
 
+from ixdiagnose.utils.command import Command
+from ixdiagnose.utils.middleware import MiddlewareClient, MiddlewareCommand
 from ixdiagnose.utils.run import run
 
 from .base import Plugin
-from .metrics import PythonMetric
+from .metrics import CommandMetric, FileMetric, MiddlewareClientMetric, PythonMetric
+from .prerequisites import LibvirtContainersPrerequisite
+
+
+CONTAINERS_LIBVIRT_URI = 'lxc:///system?socket=/run/truenas_libvirt/libvirt-sock'
 
 
 def nspawn_containers(client, context):
@@ -16,8 +23,75 @@ def nspawn_containers(client, context):
         return []
 
 
+def libvirt_container_domains(client: MiddlewareClient, context: Any) -> str:
+    """Dump the libvirt view of every container domain (state plus rendered XML)."""
+    sections = []
+
+    listing = run(['virsh', '-c', CONTAINERS_LIBVIRT_URI, 'list', '--all'], check=False)
+    sections.append(f'$ virsh list --all\n{listing.stdout or listing.stderr}')
+
+    names = run(['virsh', '-c', CONTAINERS_LIBVIRT_URI, 'list', '--all', '--name'], check=False)
+    for name in filter(None, (line.strip() for line in names.stdout.splitlines())):
+        dumpxml = run(['virsh', '-c', CONTAINERS_LIBVIRT_URI, 'dumpxml', name], check=False)
+        sections.append(f'$ virsh dumpxml {name}\n{dumpxml.stdout or dumpxml.stderr}')
+
+    return '\n\n'.join(sections)
+
+
 class Containers(Plugin):
     name = 'containers'
     metrics = [
         PythonMetric('nspawn_containers', nspawn_containers, serializable=True),
+        MiddlewareClientMetric(
+            'global_config', [
+                MiddlewareCommand('lxc.config'),
+                MiddlewareCommand('lxc.bridge_choices'),
+                MiddlewareCommand('container.pool_choices'),
+            ]
+        ),
+        MiddlewareClientMetric('containers', [MiddlewareCommand('container.query')]),
+        MiddlewareClientMetric('container_devices', [MiddlewareCommand('container.device.query')]),
+        MiddlewareClientMetric(
+            'device_choices', [
+                MiddlewareCommand('container.device.nic_attach_choices'),
+                MiddlewareCommand('container.device.usb_choices'),
+                MiddlewareCommand('container.device.gpu_choices'),
+            ]
+        ),
+        MiddlewareClientMetric('images', [MiddlewareCommand('container.image.query_registry')]),
+        PythonMetric(
+            'libvirt_domains', libvirt_container_domains, description='Libvirt container domains',
+            prerequisites=[LibvirtContainersPrerequisite()], serializable=False,
+        ),
+        FileMetric('dnsmasq_conf', '/var/lib/dnsmasq/test.dnsmasq.raw', extension='.conf'),
+        FileMetric('dnsmasq_hosts', '/var/lib/dnsmasq/test.dnsmasq.hosts'),
+        FileMetric('dnsmasq_leases', '/var/lib/dnsmasq/dnsmasq.leases'),
+        CommandMetric(
+            'runtime_state', [
+                Command(
+                    ['find', '/run/truenas_containers', '-maxdepth', '2', '-ls'],
+                    'Container runtime/idmap state tree', serializable=False,
+                ),
+            ]
+        ),
+    ]
+    raw_metrics = [
+        CommandMetric(
+            'bridge', [
+                Command(['ip', '-d', 'link', 'show', 'truenasbr0'], 'Container bridge link', serializable=False),
+                Command(['ip', 'addr', 'show', 'truenasbr0'], 'Container bridge addresses', serializable=False),
+                Command(['bridge', 'link', 'show'], 'Bridge ports', serializable=False),
+                Command(['bridge', 'fdb', 'show'], 'Bridge forwarding database', serializable=False),
+            ]
+        ),
+    ]
+    serializable_metrics = [
+        CommandMetric(
+            'bridge', [
+                Command(['ip', '-d', '-j', 'link', 'show', 'truenasbr0'], 'Container bridge link'),
+                Command(['ip', '-j', 'addr', 'show', 'truenasbr0'], 'Container bridge addresses'),
+                Command(['bridge', '-j', 'link', 'show'], 'Bridge ports'),
+                Command(['bridge', '-j', 'fdb', 'show'], 'Bridge forwarding database'),
+            ]
+        ),
     ]

--- a/ixdiagnose/plugins/prerequisites/__init__.py
+++ b/ixdiagnose/plugins/prerequisites/__init__.py
@@ -3,6 +3,7 @@ from .base import Prerequisite
 from .failover import FailoverPrerequisite
 from .fc import FibreChannelPrerequisite
 from .jbof import JBOFPrerequisite
+from .libvirt import LibvirtContainersPrerequisite
 from .service import ServiceRunningPrerequisite
 from .vm import VMPrerequisite
 
@@ -12,6 +13,7 @@ __all__ = [
     'FailoverPrerequisite',
     'FibreChannelPrerequisite',
     'JBOFPrerequisite',
+    'LibvirtContainersPrerequisite',
     'VMPrerequisite',
     'Prerequisite',
     'ServiceRunningPrerequisite',

--- a/ixdiagnose/plugins/prerequisites/libvirt.py
+++ b/ixdiagnose/plugins/prerequisites/libvirt.py
@@ -1,0 +1,19 @@
+import os
+
+from .base import Prerequisite
+
+
+CONTAINERS_LIBVIRT_SOCKET = '/run/truenas_libvirt/libvirt-sock'
+
+
+class LibvirtContainersPrerequisite(Prerequisite):
+
+    def __init__(self):
+        super().__init__(True)
+        self.cache_key = 'libvirt_containers_socket'
+
+    def evaluate_impl(self) -> bool:
+        return os.path.exists(CONTAINERS_LIBVIRT_SOCKET)
+
+    def __str__(self):
+        return 'libvirt containers socket existence check'


### PR DESCRIPTION
## Problem
The `containers` plugin only listed systemd-nspawn machines via `machinectl`, so debugs captured nothing about the new LXC/libvirt `container` middleware plugin (global config, containers, devices, images) or its host-level runtime and network state. Incus/libvirt logs were the only incidental coverage.

## Solution
Extended the `containers` plugin to capture the container plugin's middleware config (`lxc.config`, `lxc.bridge_choices`, `container.pool_choices`, `container.query`, `container.device.query`, the device `*_choices`, and `container.image.query_registry`) alongside host state: a libvirt dump (`virsh list --all` plus `dumpxml` per domain over the container URI), the `truenasbr0` bridge view, the dnsmasq conf/hosts/leases files, and the `/run/truenas_containers` runtime tree. The libvirt dump is gated behind a new `LibvirtContainersPrerequisite` that checks for the container libvirt socket so it skips cleanly on systems without containers. None of the container API models carry `Secret` fields, so no redaction is needed. nft rules and container datasets are intentionally left to the `network` and `zfs` plugins to avoid duplication.