### PR TITLE
NAS-141447 / 26.0.0-RC.1 / Run CI against the middleware:26 image

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -7,7 +7,7 @@ jobs:
 
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/truenas/middleware:master
+      image: ghcr.io/truenas/middleware:26
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -13,7 +13,7 @@ jobs:
   add-coverage:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/truenas/middleware:master
+      image: ghcr.io/truenas/middleware:26
     steps:
     - name: Checkout code
       uses: actions/checkout@v2

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -7,7 +7,7 @@ jobs:
 
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/truenas/middleware:master
+      image: ghcr.io/truenas/middleware:26
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
## Problem
The unit, integration, and coverage workflows pinned `ghcr.io/truenas/middleware:master`. On this branch `ixdiagnose/utils/formatter.py` imports `get` from `middlewared.utils.filter_list`, which exists in the 26 middleware but not in master, so every test job failed at collection time with `ImportError: cannot import name 'get' from 'middlewared.utils.filter_list'`.

## Solution
Pointed all three workflows at `ghcr.io/truenas/middleware:26` so CI runs against the middleware this branch actually targets. Verified locally in that image: unit (95 passed) and integration (25 passed) suites both pass.