### PR TITLE
NAS-141454 / 26.0.0-RC.1 / Add missing logs (by anodos325)

### DIFF
--- a/ixdiagnose/artifacts/logs.py
+++ b/ixdiagnose/artifacts/logs.py
@@ -7,6 +7,8 @@ class Logs(Artifact):
     name = 'logs'
     individual_item_max_size_limit = 10 * 1024 * 1024
     items = [
+        DirectoryPattern('audit', pattern=r'^audit_handler\.log'),
+        DirectoryPattern('ctdb'),
         DirectoryPattern('incus'),
         DirectoryPattern('jobs'),
         DirectoryPattern('libvirt'),
@@ -35,9 +37,13 @@ class Logs(Artifact):
         File('truenas_connect.log'),
         File('truenas_verify.log'),
         File('wsdd.log'),
+        Pattern('cron.+'),
         Pattern('daemon.+'),
+        Pattern('docker_image.+'),
         Pattern('failover.+'),
         Pattern('fenced.+'),
+        Pattern('mail.+'),
         Pattern('middlewared.+'),
+        Pattern('truenas-discoveryd.+'),
         Pattern('zettarepl.+'),
     ]

--- a/ixdiagnose/plugins/discovery.py
+++ b/ixdiagnose/plugins/discovery.py
@@ -1,0 +1,34 @@
+from ixdiagnose.utils.command import Command
+
+from .base import Plugin
+from .metrics import CommandMetric, FileMetric
+from .prerequisites import ServiceRunningPrerequisite
+
+
+class Discovery(Plugin):
+    name = 'discovery'
+    metrics = [
+        CommandMetric(
+            'discovery_status', [
+                Command(
+                    ['truenas-discovery-status'],
+                    'TrueNAS discovery daemon runtime status (mDNS/NetBIOS/WS-Discovery)',
+                    serializable=True,
+                ),
+            ], prerequisites=[ServiceRunningPrerequisite('truenas-discoveryd')],
+        ),
+        FileMetric(
+            'truenas-discoveryd', '/etc/truenas-discovery/truenas-discoveryd.conf', extension='.conf'
+        ),
+    ]
+    raw_metrics = [
+        CommandMetric(
+            'service_status', [
+                Command(
+                    ['systemctl', 'status', 'truenas-discoveryd'],
+                    'TrueNAS discovery service status',
+                    serializable=False, safe_returncodes=[0, 3],
+                ),
+            ],
+        ),
+    ]

--- a/ixdiagnose/plugins/factory.py
+++ b/ixdiagnose/plugins/factory.py
@@ -9,6 +9,7 @@ from .containers import Containers
 from .cpu import Cpu
 from .cronjob import Cronjob
 from .directoryservices import DirectoryServices
+from .discovery import Discovery
 from .exceptions import LoggedExceptions
 from .failover import Failover
 from .fc import FibreChannel
@@ -55,6 +56,7 @@ for plugin in [
     Cpu,
     Cronjob,
     DirectoryServices,
+    Discovery,
     Failover,
     FibreChannel,
     FTP,


### PR DESCRIPTION
* truenas-discoveryd
* truenas-zfsrewrited
* user
* a few other ones referenced in our syslog-ng config

Original PR: https://github.com/truenas/ixdiagnose/pull/358
