### PR TITLE
NAS-141594 / 27.0.0-BETA.1 / Capture CPU SMT topology, hwmon, and CPU temperature aggregate

### DIFF
--- a/ixdiagnose/artifacts/factory.py
+++ b/ixdiagnose/artifacts/factory.py
@@ -3,6 +3,7 @@ from ixdiagnose.utils.factory import Factory
 from .crashdump import Crashdump
 from .logs import Logs
 from .proc import ProcFS
+from .sys_hwmon import SysClassHwmon
 from .sys_info import SystemInfo
 from .sys_parameters import SysFSParameters
 
@@ -12,6 +13,7 @@ for artifact in [
     Crashdump,
     Logs,
     ProcFS,
+    SysClassHwmon,
     SysFSParameters,
     SystemInfo,
 ]:

--- a/ixdiagnose/artifacts/sys_hwmon.py
+++ b/ixdiagnose/artifacts/sys_hwmon.py
@@ -1,0 +1,16 @@
+from .base import Artifact
+from .items import Glob
+
+
+class SysClassHwmon(Artifact):
+    base_dir = '/sys/class/hwmon'
+    name = 'sys_hwmon'
+    individual_item_max_size_limit = 64 * 1024
+    items = [
+        Glob('hwmon*/name', relative_to='/sys/class/hwmon'),
+        Glob('hwmon*/temp*_input', relative_to='/sys/class/hwmon'),
+        Glob('hwmon*/temp*_label', relative_to='/sys/class/hwmon'),
+        Glob('hwmon*/temp*_max', relative_to='/sys/class/hwmon'),
+        Glob('hwmon*/temp*_crit', relative_to='/sys/class/hwmon'),
+        Glob('hwmon*/temp*_crit_alarm', relative_to='/sys/class/hwmon'),
+    ]

--- a/ixdiagnose/plugins/cpu.py
+++ b/ixdiagnose/plugins/cpu.py
@@ -16,8 +16,26 @@ def cpu_ppin(client, context):
     return dict(final)
 
 
+def cpu_topology(client, context):
+    topology_files = ('core_cpus_list', 'thread_siblings_list', 'core_id', 'physical_package_id', 'die_id')
+    final = {}
+    for cpu_dir in Path('/sys/devices/system/cpu/').glob('cpu[0-9]*'):
+        entry = {}
+        for filename in topology_files:
+            try:
+                entry[filename] = (cpu_dir / 'topology' / filename).read_text().strip()
+            except Exception:
+                continue
+
+        if entry:
+            final[cpu_dir.name] = entry
+
+    return final
+
+
 class Cpu(Plugin):
     name = 'cpu'
     metrics = [
         PythonMetric('cpu_ppin_info', cpu_ppin, serializable=True),
+        PythonMetric('cpu_topology_info', cpu_topology, serializable=True),
     ]

--- a/ixdiagnose/plugins/hardware.py
+++ b/ixdiagnose/plugins/hardware.py
@@ -52,6 +52,11 @@ class Hardware(Plugin):
                 Command(['sensors', '-j'], 'List of available sensors'),
             ],
         ),
+        CommandMetric(
+            'cpu_topology', [
+                Command(['lscpu', '-e=CPU,CORE,SOCKET,NODE,ONLINE'], 'CPU per-core topology', serializable=False),
+            ],
+        ),
         FileMetric('usb_devices', '/sys/kernel/debug/usb/devices'),
         MiddlewareClientMetric('disks', [AdminMiddlewareCommand('device.get_disks')]),
         MiddlewareClientMetric('disks_config', [MiddlewareCommand('disk.query')]),

--- a/ixdiagnose/plugins/reporting.py
+++ b/ixdiagnose/plugins/reporting.py
@@ -1,4 +1,4 @@
-from ixdiagnose.utils.middleware import MiddlewareCommand
+from ixdiagnose.utils.middleware import AdminMiddlewareCommand, MiddlewareCommand
 
 from .base import Plugin
 from .metrics import MiddlewareClientMetric
@@ -12,5 +12,9 @@ class Reporting(Plugin):
             'graphs', [MiddlewareCommand(
                 'reporting.netdata_graphs', result_key='all_graphs',
             )], prerequisites=[ServiceRunningPrerequisite('netdata')],
+        ),
+        MiddlewareClientMetric(
+            'cpu_temperatures', [AdminMiddlewareCommand('reporting.cpu_temperatures')],
+            prerequisites=[ServiceRunningPrerequisite('netdata')],
         ),
     ]


### PR DESCRIPTION
## Problem
The dashboard "CPU Temp" aggregate can over-report relative to the per-core sensor values, and the error depends on how the kernel numbers SMT sibling threads. A debug bundle today captures `sensors -j` and `lscpu`/`lscpu -J`, but not the SMT topology that explains a wrong aggregate, the `/sys/class/hwmon` tree the 27.0 temperature pipeline reads directly, nor the aggregate value the dashboard actually shows. Diagnosing these reports needs manual back-and-forth with reporters.

## Solution
Add four read-only captures so a single bundle is self-sufficient:

- **Per-CPU SMT topology** (`plugins/cpu.py`): a new `cpu_topology` PythonMetric reads `core_cpus_list`, `thread_siblings_list`, `core_id`, `physical_package_id`, and `die_id` per `cpuN`, exposing the sibling numbering scheme.
- **lscpu per-core table** (`plugins/hardware.py`): a `cpu_topology` CommandMetric running `lscpu -e=CPU,CORE,SOCKET,NODE,ONLINE`.
- **hwmon sysfs tree** (`artifacts/sys_hwmon.py`): a new `SysClassHwmon` artifact copying the leaf temperature files (`name`, `temp*_input`, `temp*_label`, `temp*_max`, `temp*_crit`, `temp*_crit_alarm`). It globs leaf files only so it follows the `hwmonN` symlinks to copy real contents without recursing into the `device`/`subsystem` symlinked directories.
- **CPU temperature aggregate** (`plugins/reporting.py`): a MiddlewareClientMetric for `reporting.cpu_temperatures`, which returns the per-core temps plus the `cpu` aggregate the dashboard widget displays. It uses `AdminMiddlewareCommand` because that method is private and the readonly client is rejected with EACCES.