### PR TITLE
NAS-141807 / 26.0.0-RC.1 / add zpool status -D (dedup stats) (by yocalebo)

### DIFF
--- a/ixdiagnose/plugins/zfs.py
+++ b/ixdiagnose/plugins/zfs.py
@@ -99,6 +99,10 @@ class ZFS(Plugin):
             'pool_status_guid', [Command(['zpool', 'status', '-g'], 'ZFS Pool(s) Status (with vdev GUIDs)',
                                          serializable=False)]
         ),
+        CommandMetric(
+            'pool_status_dedup', [Command(['zpool', 'status', '-D'], 'ZFS Pool(s) Status (dedup statistics)',
+                                          serializable=False)]
+        ),
         CommandMetric('pool_history', [Command(['zpool', 'history'], 'ZFS Pool(s) History', serializable=False)]),
         CommandMetric('arc_summary', [Command(['arc_summary'], 'ARC Summary', serializable=False)]),
         CommandMetric('pool_status_serialized', [


### PR DESCRIPTION
Based on customer interaction we need this in our debug. Add it. (note -DD is expensive)

Original PR: https://github.com/truenas/ixdiagnose/pull/364
